### PR TITLE
fix incorrect generation of elimination orderings

### DIFF
--- a/include/ordering.h
+++ b/include/ordering.h
@@ -4,7 +4,7 @@
 
 #ifndef MARIUS_ORDERING_H
 #define MARIUS_ORDERING_H
-
+#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 #include <batch.h>
 #include <datatypes.h>
 #include <config.h>

--- a/src/ordering.cpp
+++ b/src/ordering.cpp
@@ -154,7 +154,7 @@ map<pair<int64_t, int64_t>, int64_t> getHilbertSymmetricOrdering() {
 map<pair<int64_t, int64_t>, int64_t> getEliminationOrdering() {
     map<pair<int64_t, int64_t>, int64_t> ordering_map;
 
-    int num_elim = marius_options.storage.num_partitions - 1;
+    int num_elim = marius_options.storage.buffer_capacity - 1;
 
     vector<int64_t> curr_elim(num_elim);
 


### PR DESCRIPTION
Small bug which resulted in generating incorrect elimination orderings which result in a large number of partition swaps. 

Fixed and verified with the python buffer simulator that the orderings generated now result in the correct number of swaps.