### PR TITLE
Prepare pipeline for Multi-GPU configurations

### DIFF
--- a/src/cpp/include/pipeline.h
+++ b/src/cpp/include/pipeline.h
@@ -191,7 +191,7 @@ class Pipeline {
 
     thread initThreadOfType(int worker_type, bool *paused, ThreadStatus *status, int device_id);
 
-    virtual void addWorkersToPool(int worker_type, int num_workers) = 0;
+    virtual void addWorkersToPool(int pool_id, int worker_type, int num_workers) = 0;
 
     bool isDone();
 
@@ -232,7 +232,7 @@ class PipelineCPU : public Pipeline {
 
     ~PipelineCPU();
 
-    void addWorkersToPool(int worker_type, int num_workers) override;
+    void addWorkersToPool(int pool_id, int worker_type, int num_workers) override;
 
     void initialize() override;
 
@@ -265,7 +265,7 @@ class PipelineGPU : public Pipeline {
 
     ~PipelineGPU();
 
-    void addWorkersToPool(int worker_type, int num_workers) override;
+    void addWorkersToPool(int pool_id, int worker_type, int num_workers) override;
 
     void initialize() override;
 

--- a/src/cpp/include/util.h
+++ b/src/cpp/include/util.h
@@ -4,11 +4,10 @@
 
 #ifndef MARIUS_UTIL_H
 #define MARIUS_UTIL_H
-
+#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
 #include <torch/torch.h>
 #include <spdlog/spdlog.h>
 #include <datatypes.h>
-
 #include <iostream>
 #include <fstream>
 #include <unistd.h>

--- a/src/cpp/include/util.h
+++ b/src/cpp/include/util.h
@@ -4,7 +4,7 @@
 
 #ifndef MARIUS_UTIL_H
 #define MARIUS_UTIL_H
-#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
+
 #include <torch/torch.h>
 #include <spdlog/spdlog.h>
 #include <datatypes.h>

--- a/src/cpp/src/pipeline.cpp
+++ b/src/cpp/src/pipeline.cpp
@@ -237,7 +237,20 @@ void AccumulateGradientsWorker::run() {
 void GradientsToHostWorker::run() {
     while (*status_ != ThreadStatus::Done) {
         while (!*paused_) {
-            Queue<Batch *> *pop_queue = ((PipelineGPU *) pipeline_)->device_update_batches_[device_id_];
+
+            // transfer data to device
+            // chose device with most batches in queue:
+            int num_gpus = marius_options.general.gpu_ids.size();
+            int device_id = 0;
+            int max_size = ((PipelineGPU *) pipeline_)->device_update_batches_[0]->size();
+            for (int i = 1; i < num_gpus; i++) {
+                if (((PipelineGPU *) pipeline_)->device_update_batches_[i]->size() > max_size) {
+                    max_size = ((PipelineGPU *) pipeline_)->device_update_batches_[i]->size();
+                    device_id = i;
+                }
+            }
+
+            Queue<Batch *> *pop_queue = ((PipelineGPU *) pipeline_)->device_update_batches_[device_id];
             *status_ = ThreadStatus::WaitPop;
             auto tup = pop_queue->blocking_pop();
             bool popped = get<0>(tup);
@@ -435,30 +448,30 @@ void Pipeline::waitComplete() {
     }
 }
 
-void PipelineCPU::addWorkersToPool(int worker_type, int num_workers) {
+void PipelineCPU::addWorkersToPool(int pool_id, int worker_type, int num_workers) {
     bool *paused;
     ThreadStatus *status;
 
     for (int i = 0; i < num_workers; i++) {
         paused = new bool(true);
         status = new ThreadStatus(ThreadStatus::Paused);
-        pool_paused_[i]->emplace_back(paused);
-        pool_status_[i]->emplace_back(status);
-        pool_[i]->emplace_back(initThreadOfType(worker_type, paused, status, i));
+        pool_paused_[pool_id]->emplace_back(paused);
+        pool_status_[pool_id]->emplace_back(status);
+        pool_[pool_id]->emplace_back(initThreadOfType(worker_type, paused, status, i));
     }
 }
 
 void PipelineCPU::initialize() {
     if (train_) {
-        addWorkersToPool(EMBEDDINGS_LOADER_ID, marius_options.training_pipeline.num_embedding_loader_threads);
-        addWorkersToPool(CPU_BATCH_PREP_ID, marius_options.training_pipeline.num_compute_threads);
-        addWorkersToPool(CPU_COMPUTE_ID, marius_options.training_pipeline.num_compute_threads);
-        addWorkersToPool(CPU_ACCUMULATE_ID, marius_options.training_pipeline.num_compute_threads);
-        addWorkersToPool(UPDATE_EMBEDDINGS_ID, marius_options.training_pipeline.num_embedding_update_threads);
+        addWorkersToPool(0, EMBEDDINGS_LOADER_ID, marius_options.training_pipeline.num_embedding_loader_threads);
+        addWorkersToPool(1, CPU_BATCH_PREP_ID, marius_options.training_pipeline.num_compute_threads);
+        addWorkersToPool(2, CPU_COMPUTE_ID, marius_options.training_pipeline.num_compute_threads);
+        addWorkersToPool(3, CPU_ACCUMULATE_ID, marius_options.training_pipeline.num_compute_threads);
+        addWorkersToPool(4, UPDATE_EMBEDDINGS_ID, marius_options.training_pipeline.num_embedding_update_threads);
     } else {
-        addWorkersToPool(EMBEDDINGS_LOADER_ID, marius_options.evaluation_pipeline.num_embedding_loader_threads);
-        addWorkersToPool(CPU_BATCH_PREP_ID, marius_options.evaluation_pipeline.num_evaluate_threads);
-        addWorkersToPool(CPU_COMPUTE_ID, marius_options.evaluation_pipeline.num_evaluate_threads);
+        addWorkersToPool(0, EMBEDDINGS_LOADER_ID, marius_options.evaluation_pipeline.num_embedding_loader_threads);
+        addWorkersToPool(1, CPU_BATCH_PREP_ID, marius_options.evaluation_pipeline.num_evaluate_threads);
+        addWorkersToPool(2, CPU_COMPUTE_ID, marius_options.evaluation_pipeline.num_evaluate_threads);
     }
     auto monitor_func = [](PipelineMonitor w) { w.run(); };
     monitor_ = thread(monitor_func, PipelineMonitor(this, report_time_));
@@ -646,30 +659,45 @@ PipelineGPU::~PipelineGPU() {
     }
 }
 
-void PipelineGPU::addWorkersToPool(int worker_type, int num_workers) {
+void PipelineGPU::addWorkersToPool(int pool_id, int worker_type, int num_workers) {
     bool *paused;
     ThreadStatus *status;
 
-    for (int i = 0; i < num_workers; i++) {
-        paused = new bool(true);
-        status = new ThreadStatus(ThreadStatus::Paused);
-        pool_paused_[i]->emplace_back(paused);
-        pool_status_[i]->emplace_back(status);
-        pool_[i]->emplace_back(initThreadOfType(worker_type, paused, status, i));
+
+    if (worker_type == GPU_COMPUTE_ID) {
+        num_workers = marius_options.general.gpu_ids.size() * num_workers;
+        for (int j = 0; j < marius_options.general.gpu_ids.size(); j++) {
+            for (int i = 0; i < num_workers; i++) {
+                paused = new bool(true);
+                status = new ThreadStatus(ThreadStatus::Paused);
+                pool_paused_[pool_id]->emplace_back(paused);
+                pool_status_[pool_id]->emplace_back(status);
+                pool_[pool_id]->emplace_back(initThreadOfType(worker_type, paused, status, j));
+            }
+        }
+    }
+    else {
+        for (int i = 0; i < num_workers; i++) {
+            paused = new bool(true);
+            status = new ThreadStatus(ThreadStatus::Paused);
+            pool_paused_[pool_id]->emplace_back(paused);
+            pool_status_[pool_id]->emplace_back(status);
+            pool_[pool_id]->emplace_back(initThreadOfType(worker_type, paused, status, i));
+        }
     }
 }
 
 void PipelineGPU::initialize() {
     if (train_) {
-        addWorkersToPool(EMBEDDINGS_LOADER_ID, marius_options.training_pipeline.num_embedding_loader_threads);
-        addWorkersToPool(EMBEDDINGS_TRANSFER_ID, marius_options.training_pipeline.num_embedding_transfer_threads);
-        addWorkersToPool(GPU_COMPUTE_ID, marius_options.training_pipeline.num_compute_threads);
-        addWorkersToPool(UPDATE_TRANSFER_ID, marius_options.training_pipeline.num_compute_threads);
-        addWorkersToPool(UPDATE_EMBEDDINGS_ID, marius_options.training_pipeline.num_embedding_update_threads);
+        addWorkersToPool(0, EMBEDDINGS_LOADER_ID, marius_options.training_pipeline.num_embedding_loader_threads);
+        addWorkersToPool(1, EMBEDDINGS_TRANSFER_ID, marius_options.training_pipeline.num_embedding_transfer_threads);
+        addWorkersToPool(2, GPU_COMPUTE_ID, marius_options.training_pipeline.num_compute_threads);
+        addWorkersToPool(3, UPDATE_TRANSFER_ID, marius_options.training_pipeline.num_gradient_transfer_threads);
+        addWorkersToPool(4, UPDATE_EMBEDDINGS_ID, marius_options.training_pipeline.num_embedding_update_threads);
     } else {
-        addWorkersToPool(EMBEDDINGS_LOADER_ID, marius_options.evaluation_pipeline.num_embedding_loader_threads);
-        addWorkersToPool(EMBEDDINGS_TRANSFER_ID, marius_options.evaluation_pipeline.num_embedding_transfer_threads);
-        addWorkersToPool(GPU_COMPUTE_ID, marius_options.evaluation_pipeline.num_evaluate_threads);
+        addWorkersToPool(0, EMBEDDINGS_LOADER_ID, marius_options.evaluation_pipeline.num_embedding_loader_threads);
+        addWorkersToPool(1, EMBEDDINGS_TRANSFER_ID, marius_options.evaluation_pipeline.num_embedding_transfer_threads);
+        addWorkersToPool(2, GPU_COMPUTE_ID, marius_options.evaluation_pipeline.num_evaluate_threads);
     }
 
     auto monitor_func = [](PipelineMonitor w) { w.run(); };

--- a/src/cpp/src/pipeline.cpp
+++ b/src/cpp/src/pipeline.cpp
@@ -238,7 +238,7 @@ void GradientsToHostWorker::run() {
     while (*status_ != ThreadStatus::Done) {
         while (!*paused_) {
 
-            // transfer data to device
+            // transfer data to host
             // chose device with most batches in queue:
             int num_gpus = marius_options.general.gpu_ids.size();
             int device_id = 0;


### PR DESCRIPTION
This change modifies the pipeline to support a basic Multi-GPU configuration. 

The configuration is as follows:
- Node embeddings and relation embeddings are stored in CPU memory or within a PartitionBuffer
- Batches are piped to the GPU(s) by a pool of transfer worker threads
- A transfer worker schedules batches to the GPUs based on which one has the fewest outstanding batches on the device.
- Each GPU can have multiple pipeline worker threads, if needed.
- Another set of transfer workers transfers gradients back to the host.

Future implementations will improve the scheduling of batches and transfer of gradients, as well as add parameter replication of the relation embeddings across the GPUs. 