### PR TITLE
Add functions to store and use custom dataset statistics

### DIFF
--- a/docs/user_guide/command_line_interface.rst
+++ b/docs/user_guide/command_line_interface.rst
@@ -75,25 +75,27 @@ It is the directory where all the files created by ``marius_preprocess`` wil be 
 For the preprocessing of supported datasets, ``<output_directory>`` also includes
 the downloaded raw dataset.
 
-==================  ============
-File                Description
-------------------  ------------
-train_edges.pt      Contains edges for training set;
+============================  ============
+File                          Description
+----------------------------  ------------
+train_edges.pt                Contains edges for training set;
 
-                    Should be set for ``path.train_edges`` in Marius configuration file
-valid_edges.pt      Contains edges for validation set; 
+                              Should be set for ``path.train_edges`` in Marius configuration file
+valid_edges.pt                Contains edges for validation set; 
 
-                    Should be set for ``path.valid_edges`` in Marius configuration file
-test_edges.pt       Contains edges for test set; 
+                              Should be set for ``path.valid_edges`` in Marius configuration file
+test_edges.pt                 Contains edges for test set; 
 
-                    Should be set for ``path.train_edges`` in Marius configuration file
-node_mapping.txt    Contains 2 columns; 
+                              Should be set for ``path.train_edges`` in Marius configuration file
+node_mapping.txt              Contains 2 columns; 
 
-                    The first column is all the original node IDs from raw data, the second column is all the remapped node IDs
-rel_mapping.txt     Contains 2 columns; 
+                              The first column is all the original node IDs from raw data, the second column is all the remapped node IDs
+rel_mapping.txt               Contains 2 columns; 
 
-                    The first column is all the original relation IDs from raw data, the second column is all the remapped relation IDs
-==================  ============
+                              The first column is all the original relation IDs from raw data, the second column is all the remapped relation IDs
+
+custom_dataset_stats.json     The file which contains the statistics of the preprocessed custom dataset
+============================  ============
 
 Each edge in ``train_edges.pt``, ``valid_edges.pt``, and ``test_edges.pt`` is stored
 in the format of ``source relation destination`` on 1 row.
@@ -257,28 +259,31 @@ The available options:
 
 ::
 
-    usage: config_generator [-h] [--data_directory data_directory] [--dataset dataset | --stats num_nodes num_edge_types num_train num_valid num_test]
-    [--device [generate_config]]
-    output_directory
+    usage: config_generator [-h] [--data_directory data_directory]
+                        [--dataset dataset | --stats num_nodes num_relations num_train num_valid num_test | --dataset_stats_path dataset_stats_path]
+                        [--device [generate_config]]
+                        output_directory
 
     Generate configs
 
     positional arguments:
     output_directory      Directory to put configs
-    Also assumed to be the default directory of preprocessed data if --data_directory is not specified
+                            Also assumed to be the default directory of preprocessed data if --data_directory is not specified
 
     optional arguments:
     -h, --help            show this help message and exit
     --data_directory data_directory
-    Directory of the preprocessed data
+                            Directory of the preprocessed data
     --dataset dataset, -d dataset
-    Dataset to preprocess
-    --stats num_nodes num_edge_types num_train num_valid num_test, -s num_nodes num_edge_types num_train num_valid num_test
-    Dataset statistics
-    Enter in order of num_nodes, num_edge_types, num_train num_valid, num_test
+                            Dataset to preprocess
+    --stats num_nodes num_relations num_train num_valid num_test, -s num_nodes num_relations num_train num_valid num_test
+                            Dataset statistics
+                            Enter in order of num_nodes, num_relations, num_train num_valid, num_test
+    --dataset_stats_path dataset_stats_path, -dsp dataset_stats_path
+                            Path to the JSON file which contains custom dataset statistics
     --device [generate_config], -dev [generate_config]
-    Generates configs for a single-GPU/multi-CPU/multi-GPU training configuration file by default.
-    Valid options (default to GPU): [GPU, CPU, multi-GPU]
+                            Generates configs for a single-GPU/multi-CPU/multi-GPU training configuration file by default.
+                            Valid options (default to GPU): [GPU, CPU, multi-GPU]
 
     Specify certain config (optional): [--<section>.<key>=<value>]
 
@@ -301,6 +306,16 @@ used when ``--stats`` is in use.
 ``--stats <num_nodes> <num_relations> <num_train> <num_valid> <num_test>, -s <num_nodes> <num_relations> <num_train> <num_valid> <num_test>``
 is an **optional** argument. It specifies the stats of the dataset to be trained over. It should not be used at the same
 time with option ``--dataset``.
+
+\-\-dataset_stats_path <dataset_stats_path>, \-dsp <dataset_stats_path>
+``--dataset_stats_path <dataset_stats_path>, -dsp <dataset_stats_path>`` is 
+an **optional** argument. After a custom 
+dataset is preprocessed, a JSON is created to store the statistics of the custom 
+dataset. 
+This option can be used to specify the path to this JSON statistics file.
+Then config_generator generates a Marius configuration file based on these 
+statistics. This option should not be used when 
+option ``--dataset`` or ``--stats`` is used.
 
 \-\-device <device>, \-dev <device>
 +++++++++++++++++

--- a/src/python/tools/config_generator.py
+++ b/src/python/tools/config_generator.py
@@ -108,6 +108,7 @@ def read_dataset_stats(path):
     
     stats = list(stats_dict.values())
     num_nodes_per_file = stats[2].strip('[]').split(", ")
+    num_nodes_per_file = [int(i) for i in num_nodes_per_file]
     stats.pop(2)
     stats = stats + num_nodes_per_file
     return stats

--- a/src/python/tools/preprocess.py
+++ b/src/python/tools/preprocess.py
@@ -4,6 +4,7 @@ import re
 import shutil
 import tarfile
 import zipfile
+import json
 from pathlib import Path
 from urllib.parse import urlparse
 from urllib.request import urlretrieve
@@ -500,6 +501,15 @@ def update_param(config_dict, arg_dict):
     return config_dict
 
 
+def save_stats(stats, output_directory):
+    stats_dict = {"num_nodes": stats[0],
+                  "num_relations": stats[1],
+                  "num_edges_per_file": str(stats[2:])}
+    output_path = Path(output_directory) / Path("custom_dataset_stats.json")
+    with open(output_path, "w") as f:
+        json.dump(stats_dict, f)
+
+
 def set_args():
     parser = argparse.ArgumentParser(
                 description='Preprocess Datasets', prog='preprocess',
@@ -625,6 +635,7 @@ def main():
                                args.start_col,
                                args.num_line_skip)
 
+    save_stats(stats, args.output_directory)
 
     if args.generate_config is not None:
         dir = args.output_directory

--- a/test/python/preprocessing/test_config_generator_cmd_opt_parsing.py
+++ b/test/python/preprocessing/test_config_generator_cmd_opt_parsing.py
@@ -5,6 +5,7 @@ import shutil
 from pathlib import Path
 from marius.tools.config_generator import set_args
 from marius.tools.config_generator import parse_args
+from marius.tools.config_generator import read_dataset_stats
 from marius.tools.config_generator import read_template
 
 
@@ -178,3 +179,21 @@ class TestConfigGeneratorCmdOptParser(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             args = parser.parse_args(self.cmd_args[13])
             config_dict = parse_args(args)
+
+    def test_save_load_custom_dataset_stats(self):
+        """
+        Check if dataset stats can be stored by preprocess and loaded by
+            config_generator correctly
+        """
+        stats_path = Path("./output_dir/custom_dataset_stats.json")
+        cmd_arg = ["marius_preprocess", "./output_dir", "-d", "wn18"]
+        subprocess.run(cmd_arg)
+        self.assertTrue(stats_path.exists())
+        stats = read_dataset_stats(stats_path)
+        self.assertEqual(stats[0], 40943)
+        self.assertEqual(stats[1], 18)
+        self.assertEqual(stats[2], 141442)
+        self.assertEqual(stats[3], 5000)
+        self.assertEqual(stats[4], 5000)
+
+

--- a/test/python/preprocessing/test_config_generator_cmd_opt_parsing.py
+++ b/test/python/preprocessing/test_config_generator_cmd_opt_parsing.py
@@ -186,7 +186,7 @@ class TestConfigGeneratorCmdOptParser(unittest.TestCase):
             config_generator correctly
         """
         stats_path = Path("./output_dir/custom_dataset_stats.json")
-        cmd_arg = ["marius_preprocess", "./output_dir", "-d", "wn18"]
+        cmd_arg = ["marius_preprocess", "./output_dir", "--dataset", "wn18"]
         subprocess.run(cmd_arg)
         self.assertTrue(stats_path.exists())
         stats = read_dataset_stats(stats_path)


### PR DESCRIPTION
**Describe the pull request.**
This PR enables the preprocess to store the statistics of the preprocessed dataset into a JSON file. This PR also enables the config_generator to read the JSON file stored by the preprocess and put the statistics into the configuration file. Users can invoke this function by passing the option ``--dataset_stats_path`` with the path to the JSON file.

**How was this tested?**
This is tested by adding the test ``test_save_load_custom_dataset_stats`` (test_config_generator_cmd_opt_parsing.py line 183-198).