### PR TITLE
Remove output directory

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -164,6 +164,6 @@ jobs:
         run:   |
           python3 -c "import marius as m"
           python3 -c "from marius.tools import preprocess"
-          marius_preprocess output_dir/ --dataset fb15k
+          marius_preprocess --output_directory output_dir/ --dataset fb15k
           pytest test
 

--- a/docs/user_guide/command_line_interface.rst
+++ b/docs/user_guide/command_line_interface.rst
@@ -25,52 +25,54 @@ This command can be called with:
 
 ::
 
- marius_preprocess <output_directory> [OPTIONS]
+ marius_preprocess [OPTIONS]
 
 The available options:
 
 ::
 
- usage: preprocess [-h] [--files files [files ...]] [--dataset dataset] [--num_partitions num_partitions] [--overwrite]
- [--generate_config [generate_config]] [--format format] [--delim delim] [--dtype dtype] [--not_remap_ids]
- [--dataset_split dataset_split dataset_split] [--start_col start_col] [--num_line_skip num_line_skip]
- output_directory
+    usage: preprocess [-h] [--output_directory output_directory] [--files files [files ...] | --dataset dataset] [--num_partitions num_partitions] [--overwrite]
+                    [--generate_config [generate_config]] [--format format] [--delim delim] [--dtype dtype] [--not_remap_ids] [--dataset_split dataset_split dataset_split]
+                    [--start_col start_col] [--num_line_skip num_line_skip]
 
- Preprocess Datasets
+    Preprocess Datasets
 
- positional arguments:
- output_directory      Directory to put graph data
+    optional arguments:
+    -h, --help            show this help message and exit
+    --output_directory output_directory
+                            Directory to put graph data
+    --files files [files ...]
+                            Files containing custom dataset
+    --dataset dataset     Supported dataset to preprocess
+    --num_partitions num_partitions
+                            Number of partitions to split the edges into
+    --overwrite           Overwrites the output_directory if this is set. Otherwise, files with same the names will be treated as the data for current dataset.
+    --generate_config [generate_config], -gc [generate_config]
+                            Generates a single-GPU training configuration file by default.
+                            Valid options (default to GPU): [GPU, CPU, multi-GPU]
+    --format format       Format of data, eg. srd
+    --delim delim, -d delim
+                            Specifies the delimiter
+    --dtype dtype         Indicates the numpy.dtype
+    --not_remap_ids       If set, will not remap ids
+    --dataset_split dataset_split dataset_split, -ds dataset_split dataset_split
+                            Split dataset into specified fractions
+    --start_col start_col, -sc start_col
+                            Indicates the column index to start from
+    --num_line_skip num_line_skip, -nls num_line_skip
+                            Indicates number of lines to skip from the beginning
 
- optional arguments:
- -h, --help            show this help message and exit
- --files files [files ...]
-     Files containing custom dataset
- --dataset dataset     Supported dataset to preprocess
- --num_partitions num_partitions
-     Number of partitions to split the edges into
- --overwrite           Overwrites the output_directory if this issetOtherwise, files with same the names will be treated as the data for current dataset.
- --generate_config [generate_config], -gc [generate_config]
-     Generates a single-GPU/multi-CPU/multi-GPU training configuration file by default.
-     Valid options (default to GPU): [GPU, CPU, multi-GPU]
- --format format       Format of data, eg. srd
- --delim delim, -d delim
-     Specifies the delimiter
- --dtype dtype         Indicates the numpy.dtype
- --not_remap_ids       If set, will not remap ids
- --dataset_split dataset_split dataset_split, -ds dataset_split dataset_split
-     Split dataset into specified fractions
- --start_col start_col, -sc start_col
-     Indicates the column index to start from
- --num_line_skip num_line_skip, -nls num_line_skip
-     Indicates number of lines to skip from the beginning
-
- Specify certain config (optional): [--<section>.<key>=<value>]
+    Specify certain config (optional): [--<section>.<key>=<value>]
 
 output_directory
 ++++++++++++++++
-``<output_directory>`` is a **required** argument for ``marius_preprocess``. 
-It is the directory where all the files created by ``marius_preprocess`` wil be stored.
-``marius_preprocess`` will create this file if it does not exist.
+``<output_directory>`` is a **optional** argument for ``marius_preprocess``. 
+It is the base directory where all the files created by ``marius_preprocess`` wil be stored.
+``marius_preprocess`` will create this directory if it does not exist. If users specifies a 
+built-in dataset, the default base directory name would be ``<built-in dataset>_dataset``.
+If users want to preprocess a custom dataset, the default base directory name would 
+be ``custom_dataset``. If there is already a file with the same name, ``marius_preprocess`` 
+would incrementally append a number after the original file name.
 ``marius_preprocess`` outputs the following files to ``<output_directory>``.
 For the preprocessing of supported datasets, ``<output_directory>`` also includes
 the downloaded raw dataset.
@@ -116,7 +118,7 @@ For example, the following command preprocesses the custom dataset composed of `
 
 ::
 
- marius_preprocess output_dir --files custom_train.csv custom_valid.csv custom_test.csv
+    marius_preprocess --output_directory output_dir --files custom_train.csv custom_valid.csv custom_test.csv
 
 \-\-dataset <dataset>
 +++++++++++++++++++++
@@ -156,7 +158,7 @@ configuration file generated for dataset WordNet18 (``wn18_cpu.ini``).
 
 ::
 
- marius_preprocess ./output_dir --dataset wn18 --generate_config CPU
+    marius_preprocess --output_directory ./output_dir --dataset wn18 --generate_config CPU
 
 \-\-<section>.<key>=<value>
 +++++++++++++++++++++++++++
@@ -168,7 +170,7 @@ in the Marius configuration file generated for custom dataset composed of ``cust
 
 ::
 
- marius_preprocess ./output_dir --files custom_dataset.csv --generate_config --model.embedding_sze=256 --training.num_epochs=100
+    marius_preprocess --output_directory ./output_dir --files custom_dataset.csv --generate_config --model.embedding_sze=256 --training.num_epochs=100
 
 \-\-format <format>
 +++++++++++++++++++
@@ -182,7 +184,7 @@ storing edges in the sequence of source node, relation and destination node.
 
 ::
 
- marius_preprocess ./output_dir --files custom_dataset.csv --format src
+    marius_preprocess --output_directory ./output_dir --files custom_dataset.csv --format src
 
 \-\-delim <delim>, \-d <delim>
 +++++++++++++++++++++++++++++
@@ -224,7 +226,7 @@ validation, and test sets with a corresponding proportion of 0.99, 0.05, and 0.0
 
 ::
 
- marius_preprocess ./output_dir --files custom_dataset.csv --dataset_split 0.05 0.05
+    marius_preprocess --output_directory ./output_dir --files custom_dataset.csv --dataset_split 0.05 0.05
 
 \-\-start_col <start_col>
 +++++++++++++++++++++++++

--- a/docs/user_guide/getting_started.rst
+++ b/docs/user_guide/getting_started.rst
@@ -47,7 +47,7 @@ __kobenhavn_NN_1    _instance_hypernym  __national_capital_NN_1
 
 Training embeddings on such a graph requires three steps:
 
-#. Preprocess the dataset ``marius_preprocess output_dir/ --files custom_dataset.csv``
+#. Preprocess the dataset ``marius_preprocess --output_directory output_dir/ --files custom_dataset.csv``
 
     ``output_dir`` defines the directory to save all the preprocessed data. 
     The option ``--files`` can be used to pass the files containing the custom dataset.

--- a/docs/user_guide/preprocess.rst
+++ b/docs/user_guide/preprocess.rst
@@ -20,7 +20,9 @@ Below we will cover:
 Preprocessing CSVs, TSVs and other delimited formats
 ----------------------------------------------------------
 
-The dataset must be stored as an edge list in a delimited file format, where each row of the file(s) corresponds to a single edge in the input dataset. Where each row is a tuple of source, edge-type, and destination ids. If the input dataset has only one type of edge, then there are only two columns in the file.
+The dataset must be stored as an edge list in a delimited file format, where each row of the file(s) corresponds to a 
+single edge in the input dataset. Where each row is a tuple of source, edge-type, and destination ids. 
+If the input dataset has only one type of edge, then there are only two columns in the file.
 
 When the delimiter is a comma, the file is a standard CSV as below.
 
@@ -35,9 +37,11 @@ To perform the conversion on this dataset of ``|E|`` edges we call ``marius_prep
 
 ::
 
-    marius_preprocess example_dir/ --files example.csv
+    marius_preprocess --output_directory example_dir/ --files example.csv
 
-Where ``example_dir/`` contains the location of the dataset after preprocessing. If our file was a TSV instead, the preprocessing command will be the same as the preprocessor automatically detects the delimiter of the file.
+Where ``example_dir/`` contains the location of the dataset after preprocessing. 
+If our file was a TSV instead, the preprocessing command will be the same as the 
+preprocessor automatically detects the delimiter of the file.
 
 
 
@@ -62,7 +66,7 @@ The preprocessor supports datasets with predefined train/valid/test splits by pa
 
 ::
 
-    marius_preprocess example_dir/ --files train.csv valid.csv test.csv --delim ","
+    marius_preprocess --output_directory example_dir/ --files train.csv valid.csv test.csv --delim ","
 
 After this, the files ``valid_edges.pt`` and ``test_edges.pt`` will be created in ``example_dir`` and their paths will need to be set in the configuration file.
 
@@ -72,14 +76,14 @@ If the train/valid/test splits are not predefined, the preprocessor can perform 
 
 ::
 
-    marius_preprocess example_dir/ --files example.csv --delim "," --dataset_split .05 .1
+    marius_preprocess --output_directory example_dir/ --files example.csv --delim "," --dataset_split .05 .1
 
 
 .9/.1 train/test split.
 
 ::
 
-    marius_preprocess example_dir/ --files example.csv --delim "," --dataset_split 0 .1
+    marius_preprocess --output_directory example_dir/ --files example.csv --delim "," --dataset_split 0 .1
 
 
 Handling file headers, column order, and offset columns in the input dataset
@@ -103,7 +107,7 @@ We can preprocess this dataset using the following command
 
 ::
 
-    marius_preprocess example_dir/ --files example.csv --delim "," --num_line_skip 3 --start_col 1 --format "sdr"
+    marius_preprocess --output_directory example_dir/ --files example.csv --delim "," --num_line_skip 3 --start_col 1 --format "sdr"
 
 ``--num_line_skip 3`` Tells the preprocessor to skip the first three lines of the file.
 
@@ -118,7 +122,7 @@ Large scale graphs may have an embedding table which exceeds CPU memory capacity
 
 ::
 
-    marius_preprocess example_dir/ --files example.csv --delim "," --num_partitions 16
+    marius_preprocess --output_directory example_dir/ --files example.csv --delim "," --num_partitions 16
 
 This will partition the nodes of the graph uniformly into 16 partitions and will group the edges into edge buckets, see partition_scheme for more details. The output directory will look like the following:
 
@@ -167,7 +171,7 @@ Datasets can be downloaded and preprocessed by using:
 
 ::
 
-    marius_preprocess example_dir/ --dataset <dataset_name>
+    marius_preprocess --output_directory example_dir/ --dataset <dataset_name>
 
 Marius supports the following datasets out-of-the-box:
 
@@ -201,7 +205,7 @@ For example, preprocessing the wn18 dataset produces the following output
 
 ::
 
-    user@ubuntu: marius_preprocess output_dir/ --dataset wn18
+    user@ubuntu: marius_preprocess --output_directory output_dir/ --dataset wn18
     Downloading fetch.phpmedia=en:wordnet-mlj12.tar.gz to output_dir/fetch.phpmedia=en:wordnet-mlj12.tar.gz
     Extracting
     Extraction completed
@@ -224,7 +228,7 @@ Specific configuration options can be set by passing ``--<section>.<key>=<value>
 
 ::
 
-    marius_preprocess output_dir/ --dataset wn18 --generate_config CPU --model.embedding_size=256 --training.num_epochs=100
+    marius_preprocess --output_directory output_dir/ --dataset wn18 --generate_config CPU --model.embedding_size=256 --training.num_epochs=100
 
 This will preprocess the wn18 dataset and will generate a configuration file with following options set:
 

--- a/src/python/tools/config_generator.py
+++ b/src/python/tools/config_generator.py
@@ -44,7 +44,7 @@ def output_config(config_dict, output_dir):
             for key in opts:
                 if key.split(".")[0] == sec:
                     f.write(key.split(".")[1] +
-                            "=" + config_dict.get(key) + "\n")
+                            "=" + str(config_dict.get(key)) + "\n")
 
 
 def read_template(file):
@@ -114,22 +114,21 @@ def update_stats(stats, config_dict):
 
 
 def update_data_path(dir, config_dict):
-    config_dict.update({"path.train_edges": str(dir.strip("/") +
-                        "/train_edges.pt")})
-    config_dict.update({"path.train_edges_partitions": str(dir.strip("/") +
-                        "/train_edges_partitions.txt")})
-    config_dict.update({"path.validation_edges": str(dir.strip("/") +
-                        "/valid_edges.pt")})
-    config_dict.update({"path.test_edges": str(dir.strip("/") +
-                        "/test_edges.pt")})
-    config_dict.update({"path.node_labels": str(dir.strip("/") +
-                        "/node_mapping.txt")})
-    config_dict.update({"path.relation_labels": str(dir.strip("/") +
-                        "/rel_mapping.txt")})
-    config_dict.update({"path.node_ids": str(dir.strip("/") +
-                        "/node_mapping.bin")})
-    config_dict.update({"path.relations_ids": str(dir.strip("/") +
-                        "/rel_mapping.bin")})
+    config_dict.update({"path.train_edges": Path(dir) / Path("train_edges.pt")})
+    config_dict.update({"path.train_edges_partitions": Path(dir) /
+                        Path("/train_edges_partitions.txt")})
+    config_dict.update({"path.validation_edges": Path(dir) /
+                        Path("/valid_edges.pt")})
+    config_dict.update({"path.test_edges": Path(dir) /
+                        Path("/test_edges.pt")})
+    config_dict.update({"path.node_labels": Path(dir) /
+                        Path("/node_mapping.txt")})
+    config_dict.update({"path.relation_labels": Path(dir) /
+                        Path("/rel_mapping.txt")})
+    config_dict.update({"path.node_ids": Path(dir) /
+                        Path("/node_mapping.bin")})
+    config_dict.update({"path.relations_ids": Path(dir) /
+                        Path("/rel_mapping.bin")})
 
     return config_dict
 

--- a/src/python/tools/config_generator.py
+++ b/src/python/tools/config_generator.py
@@ -140,7 +140,7 @@ def set_args():
                 epilog=('Specify certain config (optional): ' +
                         '[--<section>.<key>=<value>]'))
     mode = parser.add_mutually_exclusive_group()
-    parser.add_argument('--output_directory', metavar='output_directory',
+    parser.add_argument('output_directory', metavar='output_directory',
                         type=str, help='Directory to put configs \nAlso ' +
                         'assumed to be the default directory of preprocessed' +
                         ' data if --data_directory is not specified')
@@ -193,11 +193,9 @@ def parse_args(args):
     if arg_dict.get("general.random_seed") == "#":
         arg_dict.pop("general.random_seed")
 
-    use_built_in_ds = None
     if arg_dict.get("dataset") is not None:
         arg_dict.update({"dataset": arg_dict.get("dataset")})
         arg_dict = update_dataset_stats(arg_dict.get("dataset"), arg_dict)
-        use_built_in
     elif arg_dict.get("stats") is not None:
         arg_dict = update_stats(arg_dict.get("stats"), arg_dict)
     else:

--- a/src/python/tools/config_generator.py
+++ b/src/python/tools/config_generator.py
@@ -67,10 +67,16 @@ def read_template(file):
     return config_dict, valid_dict
 
 
-def set_up_files(output_directory):
+def set_up_files(dir_path):
+    duplicate_idx = 0
+
+    while Path(dir_path).exists():
+        duplicate_idx = duplicate_idx + 1
+        dir_path = Path(str(dir_path) + "_" + str(duplicate_idx))
+
     try:
-        if not Path(output_directory).exists():
-            Path(output_directory).mkdir(parents=False, exist_ok=False)
+        if not Path(dir_path).exists():
+            Path(dir_path).mkdir(parents=False, exist_ok=False)
     except FileExistsError:
         print("Directory already exists.")
     except FileNotFoundError:

--- a/src/python/tools/config_generator.py
+++ b/src/python/tools/config_generator.py
@@ -140,7 +140,7 @@ def set_args():
                 epilog=('Specify certain config (optional): ' +
                         '[--<section>.<key>=<value>]'))
     mode = parser.add_mutually_exclusive_group()
-    parser.add_argument('output_directory', metavar='output_directory',
+    parser.add_argument('--output_directory', metavar='output_directory',
                         type=str, help='Directory to put configs \nAlso ' +
                         'assumed to be the default directory of preprocessed' +
                         ' data if --data_directory is not specified')
@@ -193,9 +193,11 @@ def parse_args(args):
     if arg_dict.get("general.random_seed") == "#":
         arg_dict.pop("general.random_seed")
 
+    use_built_in_ds = None
     if arg_dict.get("dataset") is not None:
         arg_dict.update({"dataset": arg_dict.get("dataset")})
         arg_dict = update_dataset_stats(arg_dict.get("dataset"), arg_dict)
+        use_built_in
     elif arg_dict.get("stats") is not None:
         arg_dict = update_stats(arg_dict.get("stats"), arg_dict)
     else:

--- a/src/python/tools/config_generator.py
+++ b/src/python/tools/config_generator.py
@@ -68,16 +68,6 @@ def read_template(file):
 
 
 def set_up_files(dir_path):
-    duplicate_idx = 0
-
-    if Path(dir_path).exists():
-        duplicate_idx += 1
-        dir_path = Path(str(dir_path) + "_" + str(duplicate_idx))
-        while dir_path.exists():
-            temp_path = str(dir_path)[:-1 * len(str(duplicate_idx))]
-            duplicate_idx += 1
-            dir_path = Path(temp_path + str(duplicate_idx))
-
     try:
         if not Path(dir_path).exists():
             Path(dir_path).mkdir(parents=False, exist_ok=False)

--- a/src/python/tools/config_generator.py
+++ b/src/python/tools/config_generator.py
@@ -70,9 +70,13 @@ def read_template(file):
 def set_up_files(dir_path):
     duplicate_idx = 0
 
-    while Path(dir_path).exists():
-        duplicate_idx = duplicate_idx + 1
+    if Path(dir_path).exists():
+        duplicate_idx += 1
         dir_path = Path(str(dir_path) + "_" + str(duplicate_idx))
+        while dir_path.exists():
+            temp_path = str(dir_path)[:-1 * len(str(duplicate_idx))]
+            duplicate_idx += 1
+            dir_path = Path(temp_path + str(duplicate_idx))
 
     try:
         if not Path(dir_path).exists():
@@ -81,6 +85,8 @@ def set_up_files(dir_path):
         print("Directory already exists.")
     except FileNotFoundError:
         print("Incorrect parent path given for output directory.")
+
+    return dir_path
 
 
 def update_dataset_stats(dataset, config_dict):

--- a/src/python/tools/preprocess.py
+++ b/src/python/tools/preprocess.py
@@ -15,7 +15,7 @@ import torch
 
 from marius.tools.config_generator import output_config
 from marius.tools.config_generator import read_template
-#from marius.tools.config_generator import set_up_files
+from marius.tools.config_generator import set_up_files
 from marius.tools.config_generator import update_stats
 from marius.tools.config_generator import update_data_path
 from marius.tools.config_generator import DEFAULT_CONFIG_FILE
@@ -402,8 +402,7 @@ def parse_ogbl(files, has_rel, output_dir, num_partitions=1):
 
 def download_file(url, output_dir):
     output_dir = Path(output_dir)
-    if not output_dir.exists():
-        output_dir.mkdir()
+    assert(Path(output_dir).exists()), "Output directory not found"
 
     url_components = urlparse(url)
     filename = Path(url_components.path + url_components.query).name
@@ -592,6 +591,7 @@ def main():
     parser, config_dict = set_args()
     args = parser.parse_args()
     config_dict, arg_dict, output_dir = parse_args(config_dict, args)
+    print(f"output directory set to {output_dir}")
 
     dataset_dict = {
         "twitter": twitter,

--- a/src/python/tools/preprocess.py
+++ b/src/python/tools/preprocess.py
@@ -15,7 +15,6 @@ import torch
 
 from marius.tools.config_generator import output_config
 from marius.tools.config_generator import read_template
-from marius.tools.config_generator import set_up_files
 from marius.tools.config_generator import update_stats
 from marius.tools.config_generator import update_data_path
 from marius.tools.config_generator import DEFAULT_CONFIG_FILE
@@ -467,6 +466,28 @@ def extract_file(filepath):
 
     print("Extraction completed")
     return filepath.parent
+
+
+def set_up_files(dir_path):
+    duplicate_idx = 0
+
+    if Path(dir_path).exists():
+        duplicate_idx += 1
+        dir_path = Path(str(dir_path) + "_" + str(duplicate_idx))
+        while dir_path.exists():
+            temp_path = str(dir_path)[:-1 * len(str(duplicate_idx))]
+            duplicate_idx += 1
+            dir_path = Path(temp_path + str(duplicate_idx))
+
+    try:
+        if not Path(dir_path).exists():
+            Path(dir_path).mkdir(parents=False, exist_ok=False)
+    except FileExistsError:
+        print("Directory already exists.")
+    except FileNotFoundError:
+        print("Incorrect parent path given for output directory.")
+
+    return dir_path
 
 
 def update_param(config_dict, arg_dict):

--- a/test/python/bindings/test_fb15k.py
+++ b/test/python/bindings/test_fb15k.py
@@ -14,7 +14,7 @@ class TestFB15K(unittest.TestCase):
 
     @classmethod
     def setUp(self):
-        output_path = set_up_files("output_dir")
+        self.output_path = set_up_files("output_dir")
 
     @classmethod
     def tearDown(self):

--- a/test/python/bindings/test_fb15k.py
+++ b/test/python/bindings/test_fb15k.py
@@ -15,7 +15,6 @@ class TestFB15K(unittest.TestCase):
     @classmethod
     def setUp(self):
         self.output_path = set_up_files("output_dir")
-        print(self.output_path)
 
     @classmethod
     def tearDown(self):

--- a/test/python/bindings/test_fb15k.py
+++ b/test/python/bindings/test_fb15k.py
@@ -15,6 +15,7 @@ class TestFB15K(unittest.TestCase):
     @classmethod
     def setUp(self):
         self.output_path = set_up_files("output_dir")
+        print(self.output_path)
 
     @classmethod
     def tearDown(self):

--- a/test/python/bindings/test_fb15k.py
+++ b/test/python/bindings/test_fb15k.py
@@ -6,14 +6,20 @@ import pytest
 import os
 import marius as m
 from marius.tools import preprocess
+from marius.tools.config_generator import set_up_files
 
 
 class TestFB15K(unittest.TestCase):
+    output_path = None
+
+    @classmethod
+    def setUp(self):
+        output_path = set_up_files("output_dir")
 
     @classmethod
     def tearDown(self):
-        if Path("output_dir").exists():
-            shutil.rmtree(Path("output_dir"))
+        if Path(self.output_path).exists():
+            shutil.rmtree(Path(self.output_path))
         if Path("training_data").exists():
             shutil.rmtree(Path("training_data"))
 

--- a/test/python/postprocess/test_postprocess.py
+++ b/test/python/postprocess/test_postprocess.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from marius.tools.postprocess import get_embs
 from marius.tools.postprocess import output_embeddings
 from marius.tools.preprocess import wn18
+from marius.tools.config_generator import set_up_files
 import subprocess
 import shutil
 import numpy as np
@@ -22,6 +23,7 @@ class TestPostprocess(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
+        self.dataset_dir = set_up_files(self.dataset_dir)
         wn18(str(self.dataset_dir))
         
         if not Path("./data/marius/embeddings").exists():
@@ -39,8 +41,8 @@ class TestPostprocess(unittest.TestCase):
         if Path("./data").exists():
             shutil.rmtree(Path("./data"))
         
-        if Path("./output_dir").exists():
-            shutil.rmtree(Path("./output_dir"))
+        if Path(self.dataset_dir).exists():
+            shutil.rmtree(Path(self.dataset_dir))
 
     def test_get_embs(self):
         """

--- a/test/python/predict/test_predict.py
+++ b/test/python/predict/test_predict.py
@@ -8,6 +8,7 @@ from marius.tools.preprocess import wn18
 from marius.tools.predict import parse_infer_list
 from marius.tools.predict import set_args
 from marius.tools.predict import perform_link_prediction
+from marius.tools.config_generator import set_up_files
 
 class TestPredict(unittest.TestCase):
     """
@@ -23,6 +24,7 @@ class TestPredict(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
+        self.dataset_dir = set_up_files(self.dataset_dir)
         wn18(str(self.dataset_dir))
         
         if not Path("./data/marius/embeddings").exists():
@@ -40,8 +42,8 @@ class TestPredict(unittest.TestCase):
         if Path("./data").exists():
             shutil.rmtree(Path("./data"))
         
-        if Path("./output_dir").exists():
-            shutil.rmtree(Path("./output_dir"))
+        if Path(self.dataset_dir).exists():
+            shutil.rmtree(Path(self.dataset_dir))
 
     def test_cmd_line_infer_list(self):
         """

--- a/test/python/preprocessing/test_preprocess_cmd_opt_parsing.py
+++ b/test/python/preprocessing/test_preprocess_cmd_opt_parsing.py
@@ -45,11 +45,6 @@ class TestPreprocessCmdOptParser(unittest.TestCase):
 
     dataset_dirs = []
 
-    # @classmethod
-    # def setUp(self):
-    #     if not Path("./output_dir").exists():
-    #         Path("./output_dir").mkdir()
-
     @classmethod
     def tearDown(self):
         for dir in self.dataset_dirs:

--- a/test/python/preprocessing/test_preprocess_cmd_opt_parsing.py
+++ b/test/python/preprocessing/test_preprocess_cmd_opt_parsing.py
@@ -118,6 +118,7 @@ class TestPreprocessCmdOptParser(unittest.TestCase):
         parser, config_dict = set_args()
         args = parser.parse_args(self.cmd_args[5])
         config_dict, arg_dict, output_dir = parse_args(config_dict, args)
+        self.dataset_dirs.append(output_dir)
         self.assertTrue(arg_dict.get("generate_config") is None)
 
     def test_output_directory_not_specified_build_in_dataset(self):
@@ -129,6 +130,7 @@ class TestPreprocessCmdOptParser(unittest.TestCase):
         parser, config_dict = set_args()
         args = parser.parse_args(self.cmd_args[6])
         config_dict, arg_dict, output_dir = parse_args(config_dict, args)
+        self.dataset_dirs.append(output_dir)
         self.assertTrue("wn18_dataset" in str(output_dir))
 
     def test_output_directory_not_spcified_custom_dataset(self):
@@ -140,6 +142,7 @@ class TestPreprocessCmdOptParser(unittest.TestCase):
         parser, config_dict = set_args()
         args = parser.parse_args(self.cmd_args[13])
         config_dict, arg_dict, output_dir = parse_args(config_dict, args)
+        self.dataset_dirs.append(output_dir)
         self.assertTrue("custom_dataset" in str(output_dir))
 
     def test_training_config_missing(self):
@@ -167,6 +170,7 @@ class TestPreprocessCmdOptParser(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             args = parser.parse_args(self.cmd_args[9])
             config_dict, arg_dict, output_dir = parse_args(config_dict, args)
+            self.dataset_dirs.append(output_dir)
 
     def test_invalid_arg(self):
         """


### PR DESCRIPTION
**Describe the pull request.**
This PR removes ``output_directory`` as a required argument for ``marius_preprocess``.

**How was this tested?**
``test_missing_arg``, ``test_output_directory_not_specified_build_in_dataset``, ``test_output_directory_not_specified_build_in_dataset`` in ``test_preprocess_cmd_opt_parsing.py`` are added and updated to test this new feature.