### PR TITLE
fix relation op and comparator for ComplEx

### DIFF
--- a/src/cpp/src/nn/decoders/edge/complex.cpp
+++ b/src/cpp/src/nn/decoders/edge/complex.cpp
@@ -5,8 +5,8 @@
 #include "nn/decoders/edge/complex.h"
 
 ComplEx::ComplEx(int num_relations, int embedding_size, torch::TensorOptions tensor_options, bool use_inverse_relations, EdgeDecoderMethod decoder_method) {
-    comparator_ = std::make_shared<CosineCompare>();
-    relation_operator_ = std::make_shared<TranslationOperator>();
+    comparator_ = std::make_shared<DotCompare>();
+    relation_operator_ = std::make_shared<ComplexHadamardOperator>();
     num_relations_ = num_relations;
     embedding_size_ = embedding_size;
     use_inverse_relations_ = use_inverse_relations;
@@ -20,11 +20,11 @@ ComplEx::ComplEx(int num_relations, int embedding_size, torch::TensorOptions ten
 
 void ComplEx::reset() {
     relations_ = torch::zeros({num_relations_, embedding_size_}, tensor_options_);
-    relations_.narrow(1, 0, (embedding_size_ / 2) - 1).fill_(1);
+    relations_.narrow(1, 0, (embedding_size_ / 2)).fill_(1);
     relations_ = register_parameter("relation_embeddings", relations_).set_requires_grad(true);
     if (use_inverse_relations_) {
         inverse_relations_ = torch::zeros({num_relations_, embedding_size_}, tensor_options_);
-        inverse_relations_.narrow(1, 0, (embedding_size_ / 2) - 1).fill_(1).set_requires_grad(true);
+        inverse_relations_.narrow(1, 0, (embedding_size_ / 2)).fill_(1).set_requires_grad(true);
         inverse_relations_ = register_parameter("inverse_relation_embeddings", inverse_relations_);
     }
 }


### PR DESCRIPTION
The ComplEx decoder was implemented using the wrong relation and comparator operators. This pull request fixes that issue.