### PR TITLE
marius_predict bug

### DIFF
--- a/docs/export_and_inference/marius_predict.rst
+++ b/docs/export_and_inference/marius_predict.rst
@@ -98,6 +98,11 @@ Contents of ``configs/fb15k237.yaml``. The test set here has been created during
           pipeline:
             sync: true
 
+Since ``storage.model_dir`` is not specified in the above configuration, ``marius_predict`` will use the latest trained model present in ``storage.dataset.dataset_dir``.
+When ``storage.model_dir`` is not specified, ``marius_train`` stores the model parameters in `model_x` directory within the `storage.dataset.dataset_dir`, where x changes 
+incrementally from 0 - 10. A maximum of 11 models are stored when `model_dir` is not specified, post which the contents in `model_10/` directory are overwritten with the 
+latest parameters. ``marius_predict`` will use the latest model for inference and save the files to that directory. If ``storage.model_dir`` is specified, the model 
+parameters will be loaded from the given directory and the generated files will be saved to the same. 
 
 Example output
 ****************************

--- a/src/cpp/python_bindings/storage/io_wrap.cpp
+++ b/src/cpp/python_bindings/storage/io_wrap.cpp
@@ -9,7 +9,7 @@ void init_io(py::module &m) {
 
     m.def("load_model", [](string filename, bool train) {
 
-        shared_ptr<MariusConfig> marius_config = loadConfig(filename, "");
+        shared_ptr<MariusConfig> marius_config = loadConfig(filename, train);
 
         std::vector<torch::Device> devices = devices_from_config(marius_config->storage);
 
@@ -24,7 +24,7 @@ void init_io(py::module &m) {
 
     m.def("load_storage", [](string filename, bool train) {
 
-        shared_ptr<MariusConfig> marius_config = loadConfig(filename, "");
+        shared_ptr<MariusConfig> marius_config = loadConfig(filename, train);
 
         std::vector<torch::Device> devices = devices_from_config(marius_config->storage);
 
@@ -40,7 +40,7 @@ void init_io(py::module &m) {
 
     m.def("init_from_config", [](string filename, bool train, bool load_storage) {
 
-        shared_ptr<MariusConfig> marius_config = loadConfig(filename, "");
+        shared_ptr<MariusConfig> marius_config = loadConfig(filename, train);
 
         std::vector<torch::Device> devices = devices_from_config(marius_config->storage);
 

--- a/src/python/tools/configuration/marius_config.py
+++ b/src/python/tools/configuration/marius_config.py
@@ -7,6 +7,7 @@ from marius.tools.configuration.constants import PathConstants
 from marius.tools.configuration.validation import *
 from dataclasses import field
 import os
+import re
 
 from pathlib import Path
 import shutil
@@ -868,7 +869,20 @@ def load_config(input_config_path, save=False):
         
         OmegaConf.save(output_config,
                        output_config.storage.model_dir + PathConstants.saved_full_config_file_name)
-
+    elif re.fullmatch("{}model_[0-9]+/".format(output_config.storage.dataset.dataset_dir), output_config.storage.model_dir):
+        # this path is taken in test cases where random configs are passed to this function for parsing.
+        # could also be taken when marius_predict is run.
+        
+        # if model_dir is of the form `model_x/`, where x belong to [0, 10], then set model_dir to the largest 
+        # existing directory. If model_dir is user specified, no need to change it. 
+        match_result = re.search(r".*/model_([0-9]+)/$", output_config.storage.model_dir)
+        last_model_id = -1
+        if len(match_result.groups()) == 1:
+            last_model_id = int(match_result.groups()[0]) - 1
+        
+        if last_model_id >= 0:
+            output_config.storage.model_dir = "{}model_{}/".format(output_config.storage.dataset.dataset_dir, last_model_id)
+            
     # we can then perform validation, and optimization over the fully specified configuration file here before returning
     validate_dataset_config(output_config)
     validate_storage_config(output_config)

--- a/src/python/tools/marius_predict.py
+++ b/src/python/tools/marius_predict.py
@@ -473,7 +473,7 @@ def run_predict(args):
 
     model_dir_path = pathlib.Path(config.storage.model_dir)
     if not model_dir_path.exists():
-        raise RuntimeError("Path {} with model params doesn't exist. Probably try training a model and then run marius_predict??".format(str(model_dir_path)))
+        raise RuntimeError("Path {} with model params doesn't exist.".format(str(model_dir_path)))
 
     model: m.nn.Model = m.storage.load_model(args.config, train=False)
     graph_storage: m.storage.GraphModelStorage = m.storage.load_storage(args.config, train=False)

--- a/src/python/tools/marius_predict.py
+++ b/src/python/tools/marius_predict.py
@@ -471,6 +471,10 @@ def run_predict(args):
     config = m.config.loadConfig(args.config)
     metrics = get_metrics(config, args)
 
+    model_dir_path = pathlib.Path(config.storage.model_dir)
+    if not model_dir_path.exists():
+        raise RuntimeError("Path {} with model params doesn't exist. Probably try training a model and then run marius_predict??".format(str(model_dir_path)))
+
     model: m.nn.Model = m.storage.load_model(args.config, train=False)
     graph_storage: m.storage.GraphModelStorage = m.storage.load_storage(args.config, train=False)
 


### PR DESCRIPTION
`marius_predict` uses the last trained model if `model_dir` isn't specified. 