### PR TITLE
Support for interval based Checkpointing

### DIFF
--- a/src/cpp/include/configuration/config.h
+++ b/src/cpp/include/configuration/config.h
@@ -113,6 +113,7 @@ struct CheckpointConfig {
     bool save_edges;
     bool save_state;
     bool save_encoded;
+    int save_prev_num;
 };
 
 struct ModelConfig {
@@ -152,7 +153,6 @@ struct TrainingConfig {
     shared_ptr<CheckpointConfig> checkpoint = nullptr;
     bool resume_training;
     string resume_from_checkpoint;
-    int checkpoint_after_epochs;
 };
 
 struct EvaluationConfig {

--- a/src/cpp/include/configuration/config.h
+++ b/src/cpp/include/configuration/config.h
@@ -152,6 +152,7 @@ struct TrainingConfig {
     shared_ptr<CheckpointConfig> checkpoint = nullptr;
     bool resume_training;
     string resume_from_checkpoint;
+    int checkpoint_after_epochs;
 };
 
 struct EvaluationConfig {

--- a/src/cpp/include/configuration/config.h
+++ b/src/cpp/include/configuration/config.h
@@ -107,13 +107,10 @@ struct PipelineConfig {
 };
 
 struct CheckpointConfig {
-    string dir;
+    // TODO: save the checkpoint which performs best on the valid/test set.
     bool save_best;
     int interval;
-    bool save_edges;
     bool save_state;
-    bool save_encoded;
-    int save_prev_num;
 };
 
 struct ModelConfig {

--- a/src/cpp/include/storage/checkpointer.h
+++ b/src/cpp/include/storage/checkpointer.h
@@ -39,6 +39,8 @@ public:
     std::tuple<std::shared_ptr<Model>, shared_ptr<GraphModelStorage> , CheckpointMeta> load(string checkpoint_dir, std::shared_ptr<MariusConfig> marius_config, bool train);
 
     void save(string checkpoint_dir, CheckpointMeta checkpoint_meta);
+
+    void create_checkpoint(string checkpoint_dir, CheckpointMeta checkpoint_meta, int epochs, int frequency);
 };
 
 #endif //MARIUS_CHECKPOINTER_H

--- a/src/cpp/include/storage/checkpointer.h
+++ b/src/cpp/include/storage/checkpointer.h
@@ -40,7 +40,7 @@ public:
 
     void save(string checkpoint_dir, CheckpointMeta checkpoint_meta);
 
-    void create_checkpoint(string checkpoint_dir, CheckpointMeta checkpoint_meta, int epochs, int frequency);
+    void create_checkpoint(string checkpoint_dir, CheckpointMeta checkpoint_meta, int epochs);
 };
 
 #endif //MARIUS_CHECKPOINTER_H

--- a/src/cpp/include/storage/checkpointer.h
+++ b/src/cpp/include/storage/checkpointer.h
@@ -18,8 +18,6 @@ struct CheckpointMeta {
     bool has_state = false;
     bool has_encoded = false;
     bool has_model = true;
-    bool has_edges = false;
-    bool has_features = false;
 };
 
 class Checkpointer {

--- a/src/cpp/python_bindings/configuration/config_wrap.cpp
+++ b/src/cpp/python_bindings/configuration/config_wrap.cpp
@@ -135,7 +135,8 @@ void init_config(py::module &m) {
         .def_readwrite("save_model", &TrainingConfig::save_model)
         .def_readwrite("checkpoint", &TrainingConfig::checkpoint)
         .def_readwrite("resume_training", &TrainingConfig::resume_training)
-        .def_readwrite("resume_from_checkpoint", &TrainingConfig::resume_from_checkpoint);
+        .def_readwrite("resume_from_checkpoint", &TrainingConfig::resume_from_checkpoint)
+        .def_readwrite("checkpoint_after_epochs", &TrainingConfig::checkpoint_after_epochs);
 
     py::class_<EvaluationConfig, std::shared_ptr<EvaluationConfig>>(m, "EvaluationConfig")
         .def(py::init<>())

--- a/src/cpp/python_bindings/configuration/config_wrap.cpp
+++ b/src/cpp/python_bindings/configuration/config_wrap.cpp
@@ -92,13 +92,9 @@ void init_config(py::module &m) {
 
     py::class_<CheckpointConfig, std::shared_ptr<CheckpointConfig>>(m, "CheckpointConfig")
         .def(py::init<>())
-        .def_readwrite("dir", &CheckpointConfig::dir)
         .def_readwrite("save_best", &CheckpointConfig::save_best)
         .def_readwrite("interval", &CheckpointConfig::interval)
-        .def_readwrite("save_edges", &CheckpointConfig::save_edges)
-        .def_readwrite("save_state", &CheckpointConfig::save_state)
-        .def_readwrite("save_encoded", &CheckpointConfig::save_encoded)
-        .def_readwrite("save_prev_num", &CheckpointConfig::save_prev_num);
+        .def_readwrite("save_state", &CheckpointConfig::save_state);
 
     py::class_<ModelConfig, std::shared_ptr<ModelConfig>>(m, "ModelConfig")
         .def(py::init<>())

--- a/src/cpp/python_bindings/configuration/config_wrap.cpp
+++ b/src/cpp/python_bindings/configuration/config_wrap.cpp
@@ -97,7 +97,8 @@ void init_config(py::module &m) {
         .def_readwrite("interval", &CheckpointConfig::interval)
         .def_readwrite("save_edges", &CheckpointConfig::save_edges)
         .def_readwrite("save_state", &CheckpointConfig::save_state)
-        .def_readwrite("save_encoded", &CheckpointConfig::save_encoded);
+        .def_readwrite("save_encoded", &CheckpointConfig::save_encoded)
+        .def_readwrite("save_prev_num", &CheckpointConfig::save_prev_num);
 
     py::class_<ModelConfig, std::shared_ptr<ModelConfig>>(m, "ModelConfig")
         .def(py::init<>())
@@ -135,8 +136,7 @@ void init_config(py::module &m) {
         .def_readwrite("save_model", &TrainingConfig::save_model)
         .def_readwrite("checkpoint", &TrainingConfig::checkpoint)
         .def_readwrite("resume_training", &TrainingConfig::resume_training)
-        .def_readwrite("resume_from_checkpoint", &TrainingConfig::resume_from_checkpoint)
-        .def_readwrite("checkpoint_after_epochs", &TrainingConfig::checkpoint_after_epochs);
+        .def_readwrite("resume_from_checkpoint", &TrainingConfig::resume_from_checkpoint);
 
     py::class_<EvaluationConfig, std::shared_ptr<EvaluationConfig>>(m, "EvaluationConfig")
         .def(py::init<>())

--- a/src/cpp/src/configuration/config.cpp
+++ b/src/cpp/src/configuration/config.cpp
@@ -417,13 +417,9 @@ shared_ptr<CheckpointConfig> initCheckpointConfig(pyobj python_config) {
 
     shared_ptr<CheckpointConfig> ret_config = std::make_shared<CheckpointConfig>();
 
-    ret_config->dir = cast_helper<string>(python_config.attr("dir"));
     ret_config->save_best = cast_helper<bool>(python_config.attr("save_best"));
     ret_config->interval = cast_helper<int>(python_config.attr("interval"));
-    ret_config->save_edges = cast_helper<bool>(python_config.attr("save_edges"));
     ret_config->save_state = cast_helper<bool>(python_config.attr("save_state"));
-    ret_config->save_encoded = cast_helper<bool>(python_config.attr("save_encoded"));
-    ret_config->save_prev_num = cast_helper<int>(python_config.attr("save_prev_num"));
     return ret_config;
 }
 

--- a/src/cpp/src/configuration/config.cpp
+++ b/src/cpp/src/configuration/config.cpp
@@ -486,6 +486,7 @@ shared_ptr<TrainingConfig> initTrainingConfig(pyobj python_config) {
     ret_config->checkpoint = initCheckpointConfig(python_config.attr("checkpoint"));
     ret_config->resume_training = cast_helper<bool>(python_config.attr("resume_training"));
     ret_config->resume_from_checkpoint = cast_helper<string>(python_config.attr("resume_from_checkpoint"));
+    ret_config->checkpoint_after_epochs = cast_helper<int>(python_config.attr("checkpoint_after_epochs"));
 
     return ret_config;
 }

--- a/src/cpp/src/configuration/config.cpp
+++ b/src/cpp/src/configuration/config.cpp
@@ -423,6 +423,7 @@ shared_ptr<CheckpointConfig> initCheckpointConfig(pyobj python_config) {
     ret_config->save_edges = cast_helper<bool>(python_config.attr("save_edges"));
     ret_config->save_state = cast_helper<bool>(python_config.attr("save_state"));
     ret_config->save_encoded = cast_helper<bool>(python_config.attr("save_encoded"));
+    ret_config->save_prev_num = cast_helper<int>(python_config.attr("save_prev_num"));
     return ret_config;
 }
 
@@ -486,7 +487,6 @@ shared_ptr<TrainingConfig> initTrainingConfig(pyobj python_config) {
     ret_config->checkpoint = initCheckpointConfig(python_config.attr("checkpoint"));
     ret_config->resume_training = cast_helper<bool>(python_config.attr("resume_training"));
     ret_config->resume_from_checkpoint = cast_helper<string>(python_config.attr("resume_from_checkpoint"));
-    ret_config->checkpoint_after_epochs = cast_helper<int>(python_config.attr("checkpoint_after_epochs"));
 
     return ret_config;
 }

--- a/src/cpp/src/marius.cpp
+++ b/src/cpp/src/marius.cpp
@@ -163,7 +163,8 @@ void marius_train(shared_ptr<MariusConfig> marius_config) {
 
 
         metadata.num_epochs = dataloader->epochs_processed_;
-        if((epoch + 1) % marius_config->training->checkpoint_after_epochs == 0 && epoch + 1 < marius_config->training->num_epochs) {
+        if(marius_config->training->checkpoint_after_epochs > 0 && (epoch + 1) % marius_config->training->checkpoint_after_epochs == 0 && 
+                epoch + 1 < marius_config->training->num_epochs) {
             model_saver->create_checkpoint(marius_config->storage->model_dir, metadata, dataloader->epochs_processed_, marius_config->training->checkpoint_after_epochs);
         }
     }

--- a/src/cpp/src/marius.cpp
+++ b/src/cpp/src/marius.cpp
@@ -18,7 +18,9 @@ void encode_and_export(shared_ptr<DataLoader> dataloader, shared_ptr<Model> mode
         graph_encoder = std::make_shared<PipelineGraphEncoder>(dataloader, model, marius_config->evaluation->pipeline);
     }
 
-    string filename = marius_config->storage->model_dir + PathConstants::encoded_nodes_file + PathConstants::file_ext;
+    string filename = marius_config->storage->model_dir
+                    + PathConstants::encoded_nodes_file
+                    + PathConstants::file_ext;
 
     if (fileExists(filename)) {
         remove(filename.c_str());
@@ -106,7 +108,7 @@ std::tuple<shared_ptr<Model>, shared_ptr<GraphModelStorage>, shared_ptr<DataLoad
     initialization_timer.stop();
     int64_t initialization_time = initialization_timer.getDuration();
 
-    SPDLOG_INFO("Initialization Complete: {}s", (double)initialization_time / 1000);
+    SPDLOG_INFO("Initialization Complete: {}s", (double) initialization_time / 1000);
 
     return std::forward_as_tuple(model, graph_model_storage, dataloader);
 }
@@ -196,7 +198,7 @@ void marius_eval(shared_ptr<MariusConfig> marius_config) {
 }
 
 void marius(int argc, char *argv[]) {
-    (void)argc;
+    (void) argc;
 
     bool train = true;
     string command_path = string(argv[0]);

--- a/src/cpp/src/marius.cpp
+++ b/src/cpp/src/marius.cpp
@@ -129,7 +129,6 @@ void marius_train(shared_ptr<MariusConfig> marius_config) {
         metadata.has_state = true;
         metadata.has_encoded = marius_config->storage->export_encoded_nodes;
         metadata.has_model = true;
-        metadata.has_edges = true;
         metadata.link_prediction = marius_config->model->learning_task == LearningTask::LINK_PREDICTION;
     }
 

--- a/src/cpp/src/storage/checkpointer.cpp
+++ b/src/cpp/src/storage/checkpointer.cpp
@@ -29,7 +29,7 @@ void Checkpointer::create_checkpoint(string checkpoint_dir, CheckpointMeta check
     std::string embeddings_state_file = checkpoint_dir + PathConstants::embeddings_state_file + PathConstants::file_ext;
 
     if (std::filesystem::exists(embeddings_file)) {
-        if (this->config_->save_encoded) std::filesystem::copy(embeddings_file, new_embeddings_file);
+        std::filesystem::copy(embeddings_file, new_embeddings_file);
         if (this->config_->save_state) std::filesystem::copy(embeddings_state_file, new_embeddings_state_file);
     }
 
@@ -37,12 +37,6 @@ void Checkpointer::create_checkpoint(string checkpoint_dir, CheckpointMeta check
 
     string final_checkpoint_dir = checkpoint_dir + "checkpoint_" + std::to_string(epochs) + "/";
     std::filesystem::rename(tmp_checkpoint_dir, final_checkpoint_dir);
-
-    int delete_checkpoint = epochs - this->config_->save_prev_num * this->config_->interval;
-    if (delete_checkpoint > 0) {
-        std::string delete_checkpoint_dir = checkpoint_dir + "checkpoint_" + std::to_string(delete_checkpoint) + "/";
-        std::filesystem::remove_all(delete_checkpoint_dir);
-    }
 }
 
 void Checkpointer::save(string checkpoint_dir, CheckpointMeta checkpoint_meta) {
@@ -60,81 +54,6 @@ void Checkpointer::save(string checkpoint_dir, CheckpointMeta checkpoint_meta) {
     }
 
     saveMetadata(checkpoint_dir, checkpoint_meta);
-
-    //    if (storage_->base_directory_ != checkpoint_dir) {
-    //
-    //        createDir(checkpoint_dir, false);
-    //        createDir(checkpoint_dir + PathConstants::edges_directory, false);
-    //        createDir(checkpoint_dir + PathConstants::nodes_directory, false);
-    //
-    //        string node_mapping_filename = storage_->base_directory_
-    //                                       + PathConstants::nodes_directory
-    //                                       + PathConstants::node_mapping_file;
-    //
-    //        string output_node_mapping_filename = checkpoint_dir
-    //                                              + PathConstants::nodes_directory
-    //                                              + PathConstants::node_mapping_file;
-    //
-    //        if (fileExists(node_mapping_filename)) {
-    //            copyFile(node_mapping_filename, output_node_mapping_filename);
-    //        }
-    //
-    //        string relation_mapping_filename = storage_->base_directory_
-    //                                           + PathConstants::edges_directory
-    //                                           + PathConstants::relation_mapping_file;
-    //
-    //        string output_relation_mapping_filename = checkpoint_dir
-    //                                                  + PathConstants::edges_directory
-    //                                                  + PathConstants::relation_mapping_file;
-    //
-    //        if (fileExists(relation_mapping_filename)) {
-    //            copyFile(relation_mapping_filename, output_relation_mapping_filename);
-    //        }
-    //
-    //        // get node embeddings and model
-    //        if (checkpoint_meta.has_model) {
-    //            string node_embedding_filename = storage_->base_directory_
-    //                                             + PathConstants::nodes_directory
-    //                                             + PathConstants::embeddings_file
-    //                                             + PathConstants::file_ext;
-    //
-    //            string output_node_embedding_filename = checkpoint_dir
-    //                                                    + PathConstants::nodes_directory
-    //                                                    + PathConstants::embeddings_file
-    //                                                    + PathConstants::file_ext;
-    //
-    //
-    //            if (fileExists(node_embedding_filename)) {
-    //                copyFile(node_embedding_filename, output_node_embedding_filename);
-    //            }
-    //
-    //            string model_filename = storage_->base_directory_ + PathConstants::model_file;
-    //            string output_model_filename = checkpoint_dir + PathConstants::model_file;
-    //
-    //            if (fileExists(model_filename)) {
-    //                copyFile(model_filename, output_model_filename);
-    //            }
-    //
-    //            if (checkpoint_meta.has_state) {
-    //                string node_state_filename = storage_->base_directory_
-    //                                             + PathConstants::nodes_directory
-    //                                             + PathConstants::embeddings_state_file
-    //                                             + PathConstants::file_ext;
-    //
-    //                string output_node_state_filename = checkpoint_dir
-    //                                                    + PathConstants::nodes_directory
-    //                                                    + PathConstants::embeddings_state_file
-    //                                                    + PathConstants::file_ext;
-    //
-    //                if (fileExists(node_state_filename)) {
-    //                    copyFile(node_state_filename, output_node_state_filename);
-    //                }
-    //            }
-    //        }
-    //        copyFile(storage_->base_directory_ + PathConstants::config_file, checkpoint_dir + PathConstants::config_file);
-    //
-    //        copyFile(storage_->base_directory_ + PathConstants::checkpoint_metadata_file, checkpoint_dir + PathConstants::checkpoint_metadata_file);
-    //    }
 }
 
 std::tuple<std::shared_ptr<Model>, shared_ptr<GraphModelStorage>, CheckpointMeta> Checkpointer::load(string checkpoint_dir,

--- a/src/cpp/src/storage/checkpointer.cpp
+++ b/src/cpp/src/storage/checkpointer.cpp
@@ -2,12 +2,14 @@
 // Created by Jason Mohoney on 12/15/21.
 //
 
+#include "storage/checkpointer.h"
+
 #include <stdio.h>
+
 #include <filesystem>
 
 #include "configuration/util.h"
 #include "reporting/logger.h"
-#include "storage/checkpointer.h"
 #include "storage/io.h"
 
 Checkpointer::Checkpointer(std::shared_ptr<Model> model, shared_ptr<GraphModelStorage> storage, std::shared_ptr<CheckpointConfig> config) {
@@ -16,58 +18,35 @@ Checkpointer::Checkpointer(std::shared_ptr<Model> model, shared_ptr<GraphModelSt
     config_ = config;
 }
 
-void Checkpointer::create_checkpoint(string checkpoint_dir, CheckpointMeta checkpoint_meta, int epochs, int frequency) {
-    int prev_checkpoint = epochs - frequency;
-    std::string prev_checkpoint_dir = checkpoint_dir + "checkpoint_" + std::to_string(prev_checkpoint) + "/";
-
+void Checkpointer::create_checkpoint(string checkpoint_dir, CheckpointMeta checkpoint_meta, int epochs) {
     string tmp_checkpoint_dir = checkpoint_dir + "checkpoint_" + std::to_string(epochs) + "_tmp/";
     std::filesystem::create_directory(tmp_checkpoint_dir);
-    
-    std::string new_embeddings_file = tmp_checkpoint_dir
-                                        + PathConstants::embeddings_file 
-                                        + PathConstants::file_ext;
-    std::string new_embeddings_state_file = tmp_checkpoint_dir
-                                            + PathConstants::embeddings_state_file
-                                            + PathConstants::file_ext;
 
-    if(std::filesystem::exists(prev_checkpoint_dir)) {
-        std::string embeddings_file = prev_checkpoint_dir 
-                                        + PathConstants::embeddings_file 
-                                        + PathConstants::file_ext;
-        std::string embeddings_state_file = prev_checkpoint_dir 
-                                                + PathConstants::embeddings_state_file
-                                                + PathConstants::file_ext;
+    std::string new_embeddings_file = tmp_checkpoint_dir + PathConstants::embeddings_file + PathConstants::file_ext;
+    std::string new_embeddings_state_file = tmp_checkpoint_dir + PathConstants::embeddings_state_file + PathConstants::file_ext;
 
-        if(std::filesystem::exists(embeddings_file)) {
-            std::filesystem::rename(embeddings_file, new_embeddings_file);
-            std::filesystem::rename(embeddings_state_file, new_embeddings_state_file);
-        }
-    } else {
-        std::string embeddings_file = checkpoint_dir 
-                                        + PathConstants::embeddings_file
-                                        + PathConstants::file_ext;
-        std::string embeddings_state_file = checkpoint_dir 
-                                                + PathConstants::embeddings_state_file
-                                                + PathConstants::file_ext;
+    std::string embeddings_file = checkpoint_dir + PathConstants::embeddings_file + PathConstants::file_ext;
+    std::string embeddings_state_file = checkpoint_dir + PathConstants::embeddings_state_file + PathConstants::file_ext;
 
-        if(std::filesystem::exists(embeddings_file)) {
-            std::filesystem::copy(embeddings_file, new_embeddings_file);
-            std::filesystem::copy(embeddings_state_file, new_embeddings_state_file);
-        }
+    if (std::filesystem::exists(embeddings_file)) {
+        if (this->config_->save_encoded) std::filesystem::copy(embeddings_file, new_embeddings_file);
+        if (this->config_->save_state) std::filesystem::copy(embeddings_state_file, new_embeddings_state_file);
     }
 
     this->save(tmp_checkpoint_dir, checkpoint_meta);
 
     string final_checkpoint_dir = checkpoint_dir + "checkpoint_" + std::to_string(epochs) + "/";
     std::filesystem::rename(tmp_checkpoint_dir, final_checkpoint_dir);
-    
-    std::filesystem::remove_all(prev_checkpoint_dir);
+
+    int delete_checkpoint = epochs - this->config_->save_prev_num * this->config_->interval;
+    if (delete_checkpoint > 0) {
+        std::string delete_checkpoint_dir = checkpoint_dir + "checkpoint_" + std::to_string(delete_checkpoint) + "/";
+        std::filesystem::remove_all(delete_checkpoint_dir);
+    }
 }
 
 void Checkpointer::save(string checkpoint_dir, CheckpointMeta checkpoint_meta) {
-
     if (checkpoint_meta.has_model) {
-
         if (storage_->storage_ptrs_.node_embeddings != nullptr) {
             storage_->storage_ptrs_.node_embeddings->write();
         }
@@ -82,87 +61,86 @@ void Checkpointer::save(string checkpoint_dir, CheckpointMeta checkpoint_meta) {
 
     saveMetadata(checkpoint_dir, checkpoint_meta);
 
-//    if (storage_->base_directory_ != checkpoint_dir) {
-//
-//        createDir(checkpoint_dir, false);
-//        createDir(checkpoint_dir + PathConstants::edges_directory, false);
-//        createDir(checkpoint_dir + PathConstants::nodes_directory, false);
-//
-//        string node_mapping_filename = storage_->base_directory_
-//                                       + PathConstants::nodes_directory
-//                                       + PathConstants::node_mapping_file;
-//
-//        string output_node_mapping_filename = checkpoint_dir
-//                                              + PathConstants::nodes_directory
-//                                              + PathConstants::node_mapping_file;
-//
-//        if (fileExists(node_mapping_filename)) {
-//            copyFile(node_mapping_filename, output_node_mapping_filename);
-//        }
-//
-//        string relation_mapping_filename = storage_->base_directory_
-//                                           + PathConstants::edges_directory
-//                                           + PathConstants::relation_mapping_file;
-//
-//        string output_relation_mapping_filename = checkpoint_dir
-//                                                  + PathConstants::edges_directory
-//                                                  + PathConstants::relation_mapping_file;
-//
-//        if (fileExists(relation_mapping_filename)) {
-//            copyFile(relation_mapping_filename, output_relation_mapping_filename);
-//        }
-//
-//        // get node embeddings and model
-//        if (checkpoint_meta.has_model) {
-//            string node_embedding_filename = storage_->base_directory_
-//                                             + PathConstants::nodes_directory
-//                                             + PathConstants::embeddings_file
-//                                             + PathConstants::file_ext;
-//
-//            string output_node_embedding_filename = checkpoint_dir
-//                                                    + PathConstants::nodes_directory
-//                                                    + PathConstants::embeddings_file
-//                                                    + PathConstants::file_ext;
-//
-//
-//            if (fileExists(node_embedding_filename)) {
-//                copyFile(node_embedding_filename, output_node_embedding_filename);
-//            }
-//
-//            string model_filename = storage_->base_directory_ + PathConstants::model_file;
-//            string output_model_filename = checkpoint_dir + PathConstants::model_file;
-//
-//            if (fileExists(model_filename)) {
-//                copyFile(model_filename, output_model_filename);
-//            }
-//
-//            if (checkpoint_meta.has_state) {
-//                string node_state_filename = storage_->base_directory_
-//                                             + PathConstants::nodes_directory
-//                                             + PathConstants::embeddings_state_file
-//                                             + PathConstants::file_ext;
-//
-//                string output_node_state_filename = checkpoint_dir
-//                                                    + PathConstants::nodes_directory
-//                                                    + PathConstants::embeddings_state_file
-//                                                    + PathConstants::file_ext;
-//
-//                if (fileExists(node_state_filename)) {
-//                    copyFile(node_state_filename, output_node_state_filename);
-//                }
-//            }
-//        }
-//        copyFile(storage_->base_directory_ + PathConstants::config_file, checkpoint_dir + PathConstants::config_file);
-//
-//        copyFile(storage_->base_directory_ + PathConstants::checkpoint_metadata_file, checkpoint_dir + PathConstants::checkpoint_metadata_file);
-//    }
+    //    if (storage_->base_directory_ != checkpoint_dir) {
+    //
+    //        createDir(checkpoint_dir, false);
+    //        createDir(checkpoint_dir + PathConstants::edges_directory, false);
+    //        createDir(checkpoint_dir + PathConstants::nodes_directory, false);
+    //
+    //        string node_mapping_filename = storage_->base_directory_
+    //                                       + PathConstants::nodes_directory
+    //                                       + PathConstants::node_mapping_file;
+    //
+    //        string output_node_mapping_filename = checkpoint_dir
+    //                                              + PathConstants::nodes_directory
+    //                                              + PathConstants::node_mapping_file;
+    //
+    //        if (fileExists(node_mapping_filename)) {
+    //            copyFile(node_mapping_filename, output_node_mapping_filename);
+    //        }
+    //
+    //        string relation_mapping_filename = storage_->base_directory_
+    //                                           + PathConstants::edges_directory
+    //                                           + PathConstants::relation_mapping_file;
+    //
+    //        string output_relation_mapping_filename = checkpoint_dir
+    //                                                  + PathConstants::edges_directory
+    //                                                  + PathConstants::relation_mapping_file;
+    //
+    //        if (fileExists(relation_mapping_filename)) {
+    //            copyFile(relation_mapping_filename, output_relation_mapping_filename);
+    //        }
+    //
+    //        // get node embeddings and model
+    //        if (checkpoint_meta.has_model) {
+    //            string node_embedding_filename = storage_->base_directory_
+    //                                             + PathConstants::nodes_directory
+    //                                             + PathConstants::embeddings_file
+    //                                             + PathConstants::file_ext;
+    //
+    //            string output_node_embedding_filename = checkpoint_dir
+    //                                                    + PathConstants::nodes_directory
+    //                                                    + PathConstants::embeddings_file
+    //                                                    + PathConstants::file_ext;
+    //
+    //
+    //            if (fileExists(node_embedding_filename)) {
+    //                copyFile(node_embedding_filename, output_node_embedding_filename);
+    //            }
+    //
+    //            string model_filename = storage_->base_directory_ + PathConstants::model_file;
+    //            string output_model_filename = checkpoint_dir + PathConstants::model_file;
+    //
+    //            if (fileExists(model_filename)) {
+    //                copyFile(model_filename, output_model_filename);
+    //            }
+    //
+    //            if (checkpoint_meta.has_state) {
+    //                string node_state_filename = storage_->base_directory_
+    //                                             + PathConstants::nodes_directory
+    //                                             + PathConstants::embeddings_state_file
+    //                                             + PathConstants::file_ext;
+    //
+    //                string output_node_state_filename = checkpoint_dir
+    //                                                    + PathConstants::nodes_directory
+    //                                                    + PathConstants::embeddings_state_file
+    //                                                    + PathConstants::file_ext;
+    //
+    //                if (fileExists(node_state_filename)) {
+    //                    copyFile(node_state_filename, output_node_state_filename);
+    //                }
+    //            }
+    //        }
+    //        copyFile(storage_->base_directory_ + PathConstants::config_file, checkpoint_dir + PathConstants::config_file);
+    //
+    //        copyFile(storage_->base_directory_ + PathConstants::checkpoint_metadata_file, checkpoint_dir + PathConstants::checkpoint_metadata_file);
+    //    }
 }
 
-std::tuple<std::shared_ptr<Model>, shared_ptr<GraphModelStorage> , CheckpointMeta> Checkpointer::load(string checkpoint_dir,
-                                                                                           std::shared_ptr<MariusConfig> marius_config,
-                                                                                           bool train) {
+std::tuple<std::shared_ptr<Model>, shared_ptr<GraphModelStorage>, CheckpointMeta> Checkpointer::load(string checkpoint_dir,
+                                                                                                     std::shared_ptr<MariusConfig> marius_config,
+                                                                                                     bool train) {
     CheckpointMeta checkpoint_meta = loadMetadata(checkpoint_dir);
-
 
     std::vector<torch::Device> devices = devices_from_config(marius_config->storage);
     std::shared_ptr<Model> model = initModelFromConfig(marius_config->model,
@@ -178,9 +156,9 @@ std::tuple<std::shared_ptr<Model>, shared_ptr<GraphModelStorage> , CheckpointMet
     }
 
     shared_ptr<GraphModelStorage> storage = initializeStorage(model,
-                                                   marius_config->storage,
-                                                   false,
-                                                   train);
+                                                              marius_config->storage,
+                                                              false,
+                                                              train);
 
     return std::forward_as_tuple(model, storage, checkpoint_meta);
 }
@@ -223,7 +201,6 @@ CheckpointMeta Checkpointer::loadMetadata(string directory) {
 }
 
 void Checkpointer::saveMetadata(string directory, CheckpointMeta checkpoint_meta) {
-
     std::ofstream output_file;
     output_file.open(directory + PathConstants::checkpoint_metadata_file);
 

--- a/src/cpp/src/storage/checkpointer.cpp
+++ b/src/cpp/src/storage/checkpointer.cpp
@@ -110,12 +110,6 @@ CheckpointMeta Checkpointer::loadMetadata(string directory) {
     std::getline(input_file, line);
     std::istringstream(line) >> ret_meta.has_model;
 
-    std::getline(input_file, line);
-    std::istringstream(line) >> ret_meta.has_edges;
-
-    std::getline(input_file, line);
-    std::istringstream(line) >> ret_meta.has_features;
-
     return ret_meta;
 }
 
@@ -130,6 +124,4 @@ void Checkpointer::saveMetadata(string directory, CheckpointMeta checkpoint_meta
     output_file << checkpoint_meta.has_state << "\n";
     output_file << checkpoint_meta.has_encoded << "\n";
     output_file << checkpoint_meta.has_model << "\n";
-    output_file << checkpoint_meta.has_edges << "\n";
-    output_file << checkpoint_meta.has_features << "\n";
 }

--- a/src/python/tools/configuration/marius_config.py
+++ b/src/python/tools/configuration/marius_config.py
@@ -701,6 +701,7 @@ class TrainingConfig:
     checkpoint: CheckpointConfig = MISSING
     resume_training: bool = False
     resume_from_checkpoint: str = ""
+    checkpoint_after_epochs: int = 5
 
     def __post_init__(self):
         if self.batch_size <= 0:
@@ -886,7 +887,7 @@ def load_config(input_config_path, save=False):
     
     if output_config.training.resume_from_checkpoint != "" and output_config.training.resume_from_checkpoint[-1] != "/":
         output_config.training.resume_from_checkpoint += "/"
-
+    
     if save and (output_config.training.resume_from_checkpoint != "" or not output_config.training.resume_training):
         # create model_dir when
         # 1. training from scratch [NOT resuming training]
@@ -906,12 +907,12 @@ def load_config(input_config_path, save=False):
         # could also be taken when marius_predict is run or marius_train is run with resume_training set to true,
         # but resume_from_checkpoint isn't specified (it will then overwrite the model_dir with new model)
         infer_model_dir(output_config)
-            
+
     # we can then perform validation, and optimization over the fully specified configuration file here before returning
     validate_dataset_config(output_config)
     validate_storage_config(output_config)
     check_encoder_layer_dimensions(output_config)
     check_gnn_layers_alignment(output_config)
     check_full_graph_evaluation(output_config)
-
+    
     return output_config

--- a/src/python/tools/configuration/marius_config.py
+++ b/src/python/tools/configuration/marius_config.py
@@ -702,7 +702,7 @@ class TrainingConfig:
     epochs_per_shuffle: int = 1
     logs_per_epoch: int = 10
     save_model: bool = True
-    checkpoint: CheckpointConfig = MISSING
+    checkpoint: CheckpointConfig = CheckpointConfig()
     resume_training: bool = False
     resume_from_checkpoint: str = ""
 
@@ -737,8 +737,6 @@ class TrainingConfig:
                             self.pipeline = PipelineConfig()
                         self.pipeline.merge(input_config.pipeline)
                     elif key == "checkpoint":
-                        if self.checkpoint is MISSING:
-                            self.checkpoint = CheckpointConfig()
                         self.checkpoint.merge(input_config.checkpoint)
                     else:
                         val = input_config.__getattr__(key)

--- a/src/python/tools/configuration/marius_config.py
+++ b/src/python/tools/configuration/marius_config.py
@@ -609,6 +609,7 @@ class CheckpointConfig:
     save_edges: bool = False
     save_state: bool = False
     save_encoded: bool = False
+    save_prev_num: int = 1
 
     def merge(self, input_config: DictConfig):
         """
@@ -634,6 +635,9 @@ class CheckpointConfig:
 
         if "save_encoded" in input_config.keys():
             self.save_encoded = input_config.save_encoded
+        
+        if "save_prev_num" in input_config.keys():
+            self.save_prev_num = input_config.save_prev_num
 
 
 @dataclass
@@ -701,7 +705,6 @@ class TrainingConfig:
     checkpoint: CheckpointConfig = MISSING
     resume_training: bool = False
     resume_from_checkpoint: str = ""
-    checkpoint_after_epochs: int = -1
 
     def __post_init__(self):
         if self.batch_size <= 0:
@@ -887,7 +890,7 @@ def load_config(input_config_path, save=False):
     
     if output_config.training.resume_from_checkpoint != "" and output_config.training.resume_from_checkpoint[-1] != "/":
         output_config.training.resume_from_checkpoint += "/"
-    
+
     if save and (output_config.training.resume_from_checkpoint != "" or not output_config.training.resume_training):
         # create model_dir when
         # 1. training from scratch [NOT resuming training]
@@ -907,12 +910,12 @@ def load_config(input_config_path, save=False):
         # could also be taken when marius_predict is run or marius_train is run with resume_training set to true,
         # but resume_from_checkpoint isn't specified (it will then overwrite the model_dir with new model)
         infer_model_dir(output_config)
-
+            
     # we can then perform validation, and optimization over the fully specified configuration file here before returning
     validate_dataset_config(output_config)
     validate_storage_config(output_config)
     check_encoder_layer_dimensions(output_config)
     check_gnn_layers_alignment(output_config)
     check_full_graph_evaluation(output_config)
-    
+
     return output_config

--- a/src/python/tools/configuration/marius_config.py
+++ b/src/python/tools/configuration/marius_config.py
@@ -603,13 +603,9 @@ class NegativeSamplingConfig:
 
 @dataclass
 class CheckpointConfig:
-    dir: str = ""
     save_best: bool = False
     interval: int = -1
-    save_edges: bool = False
     save_state: bool = False
-    save_encoded: bool = False
-    save_prev_num: int = 1
 
     def merge(self, input_config: DictConfig):
         """
@@ -618,27 +614,15 @@ class CheckpointConfig:
         :return: Structured output config
         """
 
-        if "dir" in input_config.keys():
-            self.dir = input_config.dir
-
         if "save_best" in input_config.keys():
             self.save_best = input_config.save_best
 
         if "interval" in input_config.keys():
             self.interval = input_config.interval
 
-        if "save_edges" in input_config.keys():
-            self.save_edges = input_config.save_edges
-
         if "save_state" in input_config.keys():
             self.save_state = input_config.save_state
-
-        if "save_encoded" in input_config.keys():
-            self.save_encoded = input_config.save_encoded
         
-        if "save_prev_num" in input_config.keys():
-            self.save_prev_num = input_config.save_prev_num
-
 
 @dataclass
 class PipelineConfig:

--- a/src/python/tools/configuration/marius_config.py
+++ b/src/python/tools/configuration/marius_config.py
@@ -701,7 +701,7 @@ class TrainingConfig:
     checkpoint: CheckpointConfig = MISSING
     resume_training: bool = False
     resume_from_checkpoint: str = ""
-    checkpoint_after_epochs: int = 5
+    checkpoint_after_epochs: int = -1
 
     def __post_init__(self):
         if self.batch_size <= 0:

--- a/test/python/bindings/end_to_end/test_interval_checkpointing.py
+++ b/test/python/bindings/end_to_end/test_interval_checkpointing.py
@@ -1,0 +1,119 @@
+import unittest
+import shutil
+from pathlib import Path
+import pytest
+import os
+import marius as m
+import torch
+
+from test.python.constants import TMP_TEST_DIR, TESTING_DATA_DIR
+from test.test_data.generate import generate_random_dataset
+from test.test_configs.generate_test_configs import generate_configs_for_dataset
+
+def replace_string_in_file(filepath, before, after):
+    os.system("sed -i -E 's@{}@{}@g' {}".format(before, after, filepath.__str__()))
+
+def get_line_in_file(filepath, line_num):
+    return os.popen("sed '{}!d' {}".format(line_num, filepath.__str__())).read().lstrip()
+
+def run_config(config_file, enable_checkpointing, checkpoint_interval, save_state):
+    config = m.config.loadConfig(config_file.__str__(), True)
+    config.training.num_epochs = 6
+    if enable_checkpointing:
+        config.training.checkpoint.interval = checkpoint_interval
+        config.training.checkpoint.save_state = save_state
+    m.manager.marius_train(config)
+
+class TestIntervalCheckpointing(unittest.TestCase):
+    base_dir = None
+    config_file = None
+    @classmethod
+    def setUp(self):
+        if not Path(TMP_TEST_DIR).exists():
+            Path(TMP_TEST_DIR).mkdir()
+        self.base_dir = TMP_TEST_DIR
+
+    @classmethod
+    def tearDown(self):
+        if Path(TMP_TEST_DIR).exists():
+            shutil.rmtree(Path(TMP_TEST_DIR))
+
+    def init_dataset_dir(self, name):
+        num_nodes = 100
+        num_rels = 10
+        num_edges = 1000
+
+        generate_random_dataset(output_dir=Path(self.base_dir) / Path(name),
+                                num_nodes=num_nodes,
+                                num_edges=num_edges,
+                                num_rels=num_rels,
+                                splits=[.9, .05, .05],
+                                task="lp")
+        
+        generate_configs_for_dataset(Path(self.base_dir) / Path(name),
+                                     model_names=["distmult"],
+                                     storage_names=["in_memory"],
+                                     training_names=["sync"],
+                                     evaluation_names=["sync"],
+                                     task="lp")
+        
+        for filename in os.listdir(Path(self.base_dir) / Path(name)):
+            if filename.startswith("M-"):
+                self.config_file = Path(self.base_dir) / Path(name) / Path(filename)
+
+
+    def test_checkpointing_with_state(self):
+        name = "test_checkpointing_with_state"
+        self.init_dataset_dir(name)
+        
+        # runs for a total of 6 epochs, checkpoints every 2 epochs. so checkpoint_2 & checkpoint_4 should exist
+        # checkpoint 6 shouldn't exist
+        run_config(self.config_file, True, 2, True)
+        
+        config = m.config.loadConfig(self.config_file.__str__(), False)
+        checkpoint_2_path = Path(config.storage.model_dir) / Path("checkpoint_2")
+        checkpoint_4_path = Path(config.storage.model_dir) / Path("checkpoint_4")
+        checkpoint_6_path = Path(config.storage.model_dir) / Path("checkpoint_6")
+        assert checkpoint_2_path.exists(), "Expected to see checkpointed model and params in {}, but not found".format(str(checkpoint_2_path))
+        assert checkpoint_4_path.exists(), "Expected to see checkpointed model and params in {}, but not found".format(str(checkpoint_4_path))
+        assert not checkpoint_6_path.exists(), "{} shouldn't have been created".format(str(checkpoint_6_path))
+
+        checkpoint_files = ["model.pt", "model_state.pt", "embeddings.bin", "embeddings_state.bin"]
+        for checkpoint_id in ["checkpoint_2", "checkpoint_4"]:
+            for f in checkpoint_files:
+                file_path_ = Path(config.storage.model_dir) / Path(checkpoint_id) / Path(f)
+                assert file_path_.exists(), "Expected to see checkpointed file {}, but not found".format(str(file_path_))
+
+        # resume training from checkpoint_4 and further train 5 epochs with checkpoint disabled. 
+        # so the model stored would have ideally been trained for 9 epochs.
+        full_config_path = Path(config.storage.model_dir) / Path("full_config.yaml")
+        replace_string_in_file(full_config_path, 'resume_from_checkpoint:.*', "resume_from_checkpoint: {}/checkpoint_4".format(config.storage.model_dir))
+        replace_string_in_file(full_config_path, 'model_dir:.*', '')
+        run_config(full_config_path, False, -1, False)
+
+        config = m.config.loadConfig(self.config_file.__str__(), False)
+        metadata_file_path = Path(config.storage.model_dir) / Path("metadata.csv")
+
+        trained_epochs = int(get_line_in_file(metadata_file_path, 2))
+        assert trained_epochs == 10, "Expected to see trained epochs as {} in {}, but found {}".format(10, str(metadata_file_path), trained_epochs)
+    
+    def test_checkpointing_wo_state(self):
+        name = "test_checkpointing_wo_state"
+        self.init_dataset_dir(name)
+        
+        # runs for a total of 6 epochs, checkpoints every 3 epochs. so checkpoint_3 alone should exist
+        run_config(self.config_file, True, 3, False)
+
+        config = m.config.loadConfig(self.config_file.__str__(), False)
+        checkpoint_3_path = Path(config.storage.model_dir) / Path("checkpoint_3")
+        checkpoint_6_path = Path(config.storage.model_dir) / Path("checkpoint_6")
+        assert checkpoint_3_path.exists(), "Expected to see checkpointed model and params in {}, but not found".format(str(checkpoint_3_path))
+        assert not checkpoint_6_path.exists(), "{} shouldn't have been created".format(str(checkpoint_6_path))
+        
+        checkpoint_files = ["model.pt", "model_state.pt", "embeddings.bin"]
+        for checkpoint_id in ["checkpoint_3"]:
+            for f in checkpoint_files:
+                file_path_ = Path(config.storage.model_dir) / Path(checkpoint_id) / Path(f)
+                assert file_path_.exists(), "Expected to see checkpointed file {}, but not found".format(str(file_path_))
+
+    


### PR DESCRIPTION
Introduced support for checkpointing periodically, checkpoint disabled by default. 

when enabled with `training.checkpoint.interval` set to `k`, 
writes the checkpointed model into the `<model_dir>/checkpoint_x` directory, where x=n*k. tested resuming training from the checkpointed model, works fine. 

previous checkpoints can be preserved by setting `training.checkpoint.save_prev_num`. the specified number of previous checkpoints would be preserved. 

Checkpointing Overhead
for freebase86m dataset, on cosmos 1 machine, the epoch time is around 37.2 mins (2234 secs) and the checkpointing time is around 1 min. ~3% overhead if we checkpoint for each epoch. 
```
[05/21/22 06:42:12.880] Epoch Runtime: 2233951ms
[05/21/22 06:43:12.637] Checkpoint Time: 59756ms
```