### PR TITLE
Compatibility with OmegaConf 2.2.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     tox
     pytest
     torch
-    hydra-core
+    omegaconf
     pyspark
     psutil
     GPUtil

--- a/src/python/distribution/marius_env_info.py
+++ b/src/python/distribution/marius_env_info.py
@@ -46,7 +46,7 @@ def get_gpu_info():
 
 
 def get_python_info():
-    py_deps = ['sphinx_rtd_theme', 'breathe', 'numpy', 'pandas', 'tox', 'pytest', 'torch', 'hydra', 'pyspark', 'pip']
+    py_deps = ['sphinx_rtd_theme', 'breathe', 'numpy', 'pandas', 'tox', 'pytest', 'torch', 'omegaconf', 'pyspark', 'pip']
     py_deps_version = {}
     for dep in py_deps:
         try:

--- a/src/python/tools/configuration/config_templates/marius_config.yaml
+++ b/src/python/tools/configuration/config_templates/marius_config.yaml
@@ -1,2 +1,0 @@
-defaults:
-  - base_config

--- a/test/python/bindings/integration/test_config.py
+++ b/test/python/bindings/integration/test_config.py
@@ -48,7 +48,7 @@ class TestConfig(unittest.TestCase):
             loadConfig("foo.yaml")
             raise RuntimeError("Exception not thrown")
         except Exception as e:
-            assert "Cannot find primary config" in e.__str__()
+            assert "No such file or directory" in e.__str__()
 
     def test_missing_dataset_yaml(self):
         generate_configs_for_dataset(self.output_dir,


### PR DESCRIPTION
OmegaConf recently released [version 2.2.1](https://github.com/omry/omegaconf/releases/tag/v2.2.1), this broke compatibility with how some of the list fields in our structured configuration schema are handled. 

While fixing this I found that we don't need to use [Hydra](https://hydra.cc) (which is a higher level library built on OmegaConf). We don't use any of its functionality nor will we in the near future, therefore this PR also removes the dependency on Hydra.

Summary of fixes:
- Make list fields compatible with OmegaConf 2.2.1
- Replace Hydra dependency with OmegaConf
- Minor formatting and import cleanup

Tested on MacOS and Linux locally with Python 3.10 and 3.6.9