### PR TITLE
Fix pyarrow and pyspark dependencies 

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,10 +32,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     
-    - name: Install Torch
+    - name: Install dependencies
       working-directory: ${{github.workspace}}
       shell: bash
       run:   |
+        sudo python3 -m pip install pyarrow
+
         if [ "$RUNNER_OS" == "Linux" ]; then
              sudo python3 -m pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
         elif [ "$RUNNER_OS" == "macOS" ]; then

--- a/docs/examples/config/nc_custom.rst
+++ b/docs/examples/config/nc_custom.rst
@@ -23,7 +23,6 @@ Let's borrow the provided ``examples/python/custom_nc_graphsage.py`` and modify 
     from marius.tools.preprocess.dataset import NodeClassificationDataset
     from marius.tools.preprocess.utils import download_url, extract_file
     from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
-    from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
     from marius.tools.configuration.constants import PathConstants
     from marius.tools.preprocess.datasets.dataset_helpers import remap_nodes
 
@@ -114,8 +113,7 @@ Let's borrow the provided ``examples/python/custom_nc_graphsage.py`` and modify 
             valid_nodes = np.genfromtxt(self.input_valid_nodes_file, delimiter=",").astype(np.int32)
             test_nodes = np.genfromtxt(self.input_test_nodes_file, delimiter=",").astype(np.int32)
 
-            converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-            converter = converter(
+            converter = TorchEdgeListConverter(
                 output_dir=self.output_directory,
                 train_edges=self.input_edge_list_file,
                 num_partitions=num_partitions,

--- a/examples/python/custom_nc_graphsage.py
+++ b/examples/python/custom_nc_graphsage.py
@@ -7,7 +7,6 @@ from omegaconf import OmegaConf
 
 import marius as m
 from marius.tools.configuration.constants import PathConstants
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import NodeClassificationDataset
 from marius.tools.preprocess.datasets.dataset_helpers import remap_nodes
@@ -108,8 +107,7 @@ class MYDATASET(NodeClassificationDataset):
         test_nodes = np.genfromtxt(self.input_test_nodes_file, delimiter=",").astype(np.int32)
 
         # Calling the convert function to generate the preprocessed files
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=self.input_edge_list_file,
             num_partitions=num_partitions,

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     psutil>=5.9
     GPUtil>=1.4
     importlib_metadata>=4.0.0
-    pyarrow>=6.0.0
 
 zip_safe = false
 python_requires = >=3.6

--- a/src/python/tools/preprocess/datasets/fb15k.py
+++ b/src/python/tools/preprocess/datasets/fb15k.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import LinkPredictionDataset
 from marius.tools.preprocess.utils import download_url, extract_file
@@ -46,8 +45,7 @@ class FB15K(LinkPredictionDataset):
     def preprocess(
         self, num_partitions=1, remap_ids=True, splits=None, sequential_train_nodes=False, partitioned_eval=False
     ):
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=self.input_train_edges_file,
             valid_edges=self.input_valid_edges_file,

--- a/src/python/tools/preprocess/datasets/fb15k_237.py
+++ b/src/python/tools/preprocess/datasets/fb15k_237.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import LinkPredictionDataset
 from marius.tools.preprocess.utils import download_url, extract_file
@@ -48,8 +47,7 @@ class FB15K237(LinkPredictionDataset):
     def preprocess(
         self, num_partitions=1, remap_ids=True, splits=None, sequential_train_nodes=False, partitioned_eval=False
     ):
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=self.input_train_edges_file,
             valid_edges=self.input_valid_edges_file,

--- a/src/python/tools/preprocess/datasets/freebase86m.py
+++ b/src/python/tools/preprocess/datasets/freebase86m.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import LinkPredictionDataset
 from marius.tools.preprocess.utils import download_url, extract_file
@@ -44,8 +43,7 @@ class Freebase86m(LinkPredictionDataset):
     def preprocess(
         self, num_partitions=1, remap_ids=True, splits=None, sequential_train_nodes=False, partitioned_eval=False
     ):
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=self.input_train_edges_file,
             valid_edges=self.input_valid_edges_file,

--- a/src/python/tools/preprocess/datasets/friendster.py
+++ b/src/python/tools/preprocess/datasets/friendster.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import LinkPredictionDataset
 from marius.tools.preprocess.utils import download_url, extract_file, strip_header
@@ -45,8 +44,7 @@ class Friendster(LinkPredictionDataset):
         node_splits=[0.1, 0.05, 0.05],
         partitioned_eval=False,
     ):
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=self.input_edges,
             delim="\t",

--- a/src/python/tools/preprocess/datasets/livejournal.py
+++ b/src/python/tools/preprocess/datasets/livejournal.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import LinkPredictionDataset
 from marius.tools.preprocess.utils import download_url, extract_file, strip_header
@@ -40,8 +39,7 @@ class Livejournal(LinkPredictionDataset):
         sequential_train_nodes=False,
         partitioned_eval=False,
     ):
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=self.input_edges,
             delim="\t",

--- a/src/python/tools/preprocess/datasets/ogb_mag240m.py
+++ b/src/python/tools/preprocess/datasets/ogb_mag240m.py
@@ -6,7 +6,6 @@ import torch
 from omegaconf import OmegaConf
 
 from marius.tools.configuration.constants import PathConstants
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import NodeClassificationDataset
 from marius.tools.preprocess.datasets.dataset_helpers import remap_nodes
@@ -75,8 +74,7 @@ class OGBMag240M(NodeClassificationDataset):
         # test_nodes = split_dict['test'].astype(np.int32)
         test_nodes = valid_nodes
 
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=citation_edges,
             num_partitions=num_partitions,

--- a/src/python/tools/preprocess/datasets/ogb_wikikg90mv2.py
+++ b/src/python/tools/preprocess/datasets/ogb_wikikg90mv2.py
@@ -4,7 +4,6 @@ import numpy as np
 from omegaconf import OmegaConf
 
 from marius.tools.configuration.constants import PathConstants
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import LinkPredictionDataset
 from marius.tools.preprocess.utils import download_url, extract_file
@@ -60,8 +59,7 @@ class OGBWikiKG90Mv2(LinkPredictionDataset):
 
         valid_edges = np.concatenate((valid_edges_sr, np.reshape(valid_edges_d, (-1, 1))), axis=1).astype(np.int32)
 
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=train_edges,
             valid_edges=valid_edges,

--- a/src/python/tools/preprocess/datasets/ogbl_citation2.py
+++ b/src/python/tools/preprocess/datasets/ogbl_citation2.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import LinkPredictionDataset
 from marius.tools.preprocess.utils import download_url, extract_file
@@ -57,8 +56,7 @@ class OGBLCitation2(LinkPredictionDataset):
         valid_list = np.array([valid_idx.get("source_node"), valid_idx.get("target_node")]).T
         test_list = np.array([test_idx.get("source_node"), test_idx.get("target_node")]).T
 
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=train_list,
             valid_edges=valid_list,

--- a/src/python/tools/preprocess/datasets/ogbl_ppa.py
+++ b/src/python/tools/preprocess/datasets/ogbl_ppa.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import torch
 
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import LinkPredictionDataset
 from marius.tools.preprocess.utils import download_url, extract_file
@@ -52,8 +51,7 @@ class OGBLPpa(LinkPredictionDataset):
         valid_idx = torch.load(self.input_valid_edges_file).get("edge")
         test_idx = torch.load(self.input_test_edges_file).get("edge")
 
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=train_idx,
             valid_edges=valid_idx,

--- a/src/python/tools/preprocess/datasets/ogbl_wikikg2.py
+++ b/src/python/tools/preprocess/datasets/ogbl_wikikg2.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import LinkPredictionDataset
 from marius.tools.preprocess.utils import download_url, extract_file
@@ -57,8 +56,7 @@ class OGBLWikiKG2(LinkPredictionDataset):
         valid_list = np.array([valid_idx.get("head"), valid_idx.get("relation"), valid_idx.get("tail")]).T
         test_list = np.array([test_idx.get("head"), test_idx.get("relation"), test_idx.get("tail")]).T
 
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=train_list.astype("int32"),
             valid_edges=valid_list.astype("int32"),

--- a/src/python/tools/preprocess/datasets/ogbn_arxiv.py
+++ b/src/python/tools/preprocess/datasets/ogbn_arxiv.py
@@ -4,7 +4,6 @@ import numpy as np
 from omegaconf import OmegaConf
 
 from marius.tools.configuration.constants import PathConstants
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import NodeClassificationDataset
 from marius.tools.preprocess.datasets.dataset_helpers import remap_nodes
@@ -78,8 +77,7 @@ class OGBNArxiv(NodeClassificationDataset):
         valid_nodes = np.genfromtxt(self.input_valid_nodes_file, delimiter=",").astype(np.int32)
         test_nodes = np.genfromtxt(self.input_test_nodes_file, delimiter=",").astype(np.int32)
 
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=self.input_edge_list_file,
             num_partitions=num_partitions,

--- a/src/python/tools/preprocess/datasets/ogbn_papers100m.py
+++ b/src/python/tools/preprocess/datasets/ogbn_papers100m.py
@@ -5,7 +5,6 @@ import torch
 from omegaconf import OmegaConf
 
 from marius.tools.configuration.constants import PathConstants
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import NodeClassificationDataset
 from marius.tools.preprocess.datasets.dataset_helpers import remap_nodes
@@ -73,8 +72,7 @@ class OGBNPapers100M(NodeClassificationDataset):
         valid_nodes = np.genfromtxt(self.input_valid_nodes_file, delimiter=",").astype(np.int32)
         test_nodes = np.genfromtxt(self.input_test_nodes_file, delimiter=",").astype(np.int32)
 
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=input_edges,
             num_partitions=num_partitions,

--- a/src/python/tools/preprocess/datasets/ogbn_products.py
+++ b/src/python/tools/preprocess/datasets/ogbn_products.py
@@ -4,7 +4,6 @@ import numpy as np
 from omegaconf import OmegaConf
 
 from marius.tools.configuration.constants import PathConstants
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import NodeClassificationDataset
 from marius.tools.preprocess.datasets.dataset_helpers import remap_nodes
@@ -77,8 +76,7 @@ class OGBNProducts(NodeClassificationDataset):
         valid_nodes = np.genfromtxt(self.input_valid_nodes_file, delimiter=",").astype(np.int32)
         test_nodes = np.genfromtxt(self.input_test_nodes_file, delimiter=",").astype(np.int32)
 
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=self.input_edge_list_file,
             num_partitions=num_partitions,

--- a/src/python/tools/preprocess/datasets/twitter.py
+++ b/src/python/tools/preprocess/datasets/twitter.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from marius.tools.preprocess.converters.spark_converter import SparkEdgeListConverter
 from marius.tools.preprocess.converters.torch_converter import TorchEdgeListConverter
 from marius.tools.preprocess.dataset import LinkPredictionDataset
 from marius.tools.preprocess.utils import download_url, extract_file
@@ -30,8 +29,7 @@ class Twitter(LinkPredictionDataset):
             extract_file(archive_path, remove_input=True)
 
     def preprocess(self, num_partitions=1, remap_ids=True, splits=[0.9, 0.05, 0.05], sequential_train_nodes=False):
-        converter = SparkEdgeListConverter if self.spark else TorchEdgeListConverter
-        converter = converter(
+        converter = TorchEdgeListConverter(
             output_dir=self.output_directory,
             train_edges=self.input_edges,
             delim=" ",


### PR DESCRIPTION
This PR removes pyarrow as a required dependency and the option to use pyspark for preprocessing of the built-in datasets. This fixes some breaking changes introduced in #109 and #106.

Pyarrow: 
- Currently, it breaks the pip install on some linux machines due to a Cython requirement. 
- It is only needed if exporting embeddings to parquets using Pandas. Pandas does not require pyarrow and instead lets users decide whether to use Pyarrow or fastparquet when working with parquet files. We can follow this same behavior

Pyspark:
- Pyspark was previously changed to be an optional dependency, however, this change broke preprocessing with our built-in datasets with the default pip install. 
- Imports of the built-in datasets without pyspark installed throw an import error 
- We don't need to use pyspark for our built-in datasets, as they can be assumed to fit on a single machine. 
- If users want to perform preprocessing with spark, they can call the SparkEdgeListConverter from a python script, or use the command line preprocessor for custom datasets.