### PR TITLE
Spark preprocessor now works with s3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     psutil>=5.9
     GPUtil>=1.4
     importlib_metadata>=4.0.0
+    s3fs>=2022.1.0
 
 zip_safe = false
 python_requires = >=3.6

--- a/src/python/tools/preprocess/converters/spark_converter.py
+++ b/src/python/tools/preprocess/converters/spark_converter.py
@@ -118,7 +118,8 @@ class SparkEdgeListConverter(object):
         spark_executor_memory: str = "4g",
     ):
         self.output_dir = output_dir
-
+        self.use_s3 = True if train_edges.startswith("s3a://") else False
+        
         self.spark = (
             SparkSession.builder.appName(SPARK_APP_NAME)
             .config("spark.driver.memory", spark_driver_memory)
@@ -143,7 +144,7 @@ class SparkEdgeListConverter(object):
         else:
             self.partitioner = None
 
-        self.writer = SparkWriter(self.spark, self.output_dir, partitioned_evaluation)
+        self.writer = SparkWriter(self.spark, self.output_dir, self.use_s3, partitioned_evaluation)
 
         self.train_split = None
         self.valid_split = None
@@ -232,7 +233,7 @@ class SparkEdgeListConverter(object):
             train_edges_df, valid_edges_df, test_edges_df = self.partitioner.partition_edges(
                 train_edges_df, valid_edges_df, test_edges_df, nodes_df, self.num_partitions
             )
-
+        
         return self.writer.write_to_binary(
             train_edges_df, valid_edges_df, test_edges_df, nodes_df, rels_df, self.num_partitions
         )


### PR DESCRIPTION
expects env variables `S3_BUCKET `, `AWS_ACCESS_KEY_ID ` and `AWS_SECRET_ACCESS_KEY `.  

```
marius_preprocess --edges s3a://fb15k237/train.txt s3a://fb15k237/valid.txt s3a://fb15k237/test.txt --output_directory /home/data/datasets/fb15k_237/ --spark
```

writes preprocessed output to the local directory as well as s3, can delete the files from local, but keeping them for now. 