### PR TITLE
Minor naming and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
-# Marius #
+# Marius and MariusGNN #
 
-Marius is a system for training graph neural networks and embeddings for large-scale graphs on a single machine.
+This repository contains the code for the Marius and MariusGNN papers. 
+We have combined the two works into one unified system for training 
+graph embeddings and graph neural networks over large-scale graphs 
+on a single machine using the entire memory hierarchy.
 
-Marius ([OSDI '21 Paper](https://www.usenix.org/conference/osdi21/presentation/mohoney)) is designed to mitigate/reduce data movement overheads using:
+Marius ([OSDI '21 Paper](https://www.usenix.org/conference/osdi21/presentation/mohoney)) is designed to mitigate/reduce data movement overheads for graph embeddings using:
 - Pipelined training and IO
-- Partition caching and buffer-aware data orderings
+- Partition caching and a buffer-aware data ordering to minimize IO for disk-based training (called BETA)
 
-We scale graph neural network training ([preprint](https://arxiv.org/abs/2202.02365)) through:
-- Optimized datastructures for neighbor sampling and GNN aggregation
-- Out-of-core GNN training 
+MariusGNN ([arxiv](https://arxiv.org/abs/2202.02365), to appear in EuroSys '23) 
+utilizes the data movement optimizations from Marius and adds support for scalable graph neural network training through:
+- An optimized data structure for neighbor sampling and GNN aggregation (called DENSE)
+- An improved data ordering for disk-based training (called COMET) which minimizes IO and maximizes model accuracy (note that COMET subsumes BETA)
 
 ## Build and Install ##
 
@@ -41,17 +45,20 @@ The following command line tools will be installed:
 
 ## Command Line Interface ##
 
-The command line interface supports performant in-memory and out-of-core training and evaluation of graph learning models. Experimental results from our papers can be reproduced by using this interface. 
+The command line interface supports performant in-memory and out-of-core 
+training and evaluation of graph learning models. Experimental results 
+from our papers can be reproduced using this interface (we also provide
+an exact experiment artifact for each paper in separate branches).
 
 ### Quick Start: ###
 
-First make sure marius is installed with `pip3 install .` 
+First make sure Marius is installed with `pip3 install .` 
 
-Preprocess dataset the FB15K_237 dataset with `marius_preprocess --dataset fb15k_237 --output_dir datasets/fb15k_237_example/`
+Preprocess the FB15K_237 dataset with `marius_preprocess --dataset fb15k_237 --output_dir datasets/fb15k_237_example/`
 
-Train example configuration file (assuming we are in the repo root directory) `marius_train examples/configuration/fb15k_237.yaml`
+Train using the example configuration file (assuming we are in the root directory of the repository) `marius_train examples/configuration/fb15k_237.yaml`
 
-After running this configuration, the MRR output by the system should be about .25 after 10 epochs.
+After running this configuration file, the MRR output by the system should be about .25 after 10 epochs.
 
 Perform batch inference on the test set with `marius_predict --config examples/configuration/fb15k_237.yaml --metrics mrr --save_scores --save_ranks`
 
@@ -80,14 +87,14 @@ Marius (out-of-core graph embeddings)
 }
 ```
 
-Marius++ (out-of-core GNN training)
+MariusGNN (out-of-core GNN training)
 ```
 @misc{waleffe2022marius,
   doi = {10.48550/ARXIV.2202.02365},
   url = {https://arxiv.org/abs/2202.02365},
   author = {Waleffe, Roger and Mohoney, Jason and Rekatsinas, Theodoros and Venkataraman, Shivaram},
   keywords = {Machine Learning (cs.LG), Databases (cs.DB), FOS: Computer and information sciences, FOS: Computer and information sciences},
-  title = {Marius++: Large-Scale Training of Graph Neural Networks on a Single Machine},
+  title = {MariusGNN: Resource-Efficient Out-of-Core Training of Graph Neural Networks},
   publisher = {arXiv},
   year = {2022},
 ```

--- a/src/cpp/include/configuration/options.h
+++ b/src/cpp/include/configuration/options.h
@@ -69,7 +69,7 @@ enum class StorageBackend { PARTITION_BUFFER, FLAT_FILE, HOST_MEMORY, DEVICE_MEM
 
 StorageBackend getStorageBackend(std::string string_val);
 
-enum class EdgeBucketOrdering { OLD_BETA, NEW_BETA, ALL_BETA, TWO_LEVEL_BETA, CUSTOM };
+enum class EdgeBucketOrdering { OLD_BETA, NEW_BETA, ALL_BETA, COMET, CUSTOM };
 
 EdgeBucketOrdering getEdgeBucketOrderingEnum(std::string string_val);
 

--- a/src/cpp/python_bindings/configuration/options_wrap.cpp
+++ b/src/cpp/python_bindings/configuration/options_wrap.cpp
@@ -110,7 +110,7 @@ void init_options(py::module &m) {
         .value("OLD_BETA", EdgeBucketOrdering::OLD_BETA)
         .value("NEW_BETA", EdgeBucketOrdering::NEW_BETA)
         .value("ALL_BETA", EdgeBucketOrdering::ALL_BETA)
-        .value("TWO_LEVEL_BETA", EdgeBucketOrdering::TWO_LEVEL_BETA)
+        .value("COMET", EdgeBucketOrdering::COMET)
         .value("CUSTOM", EdgeBucketOrdering::CUSTOM);
 
     m.def("getEdgeBucketOrderingEnum", &getEdgeBucketOrderingEnum, py::arg("string_val"));

--- a/src/cpp/src/configuration/options.cpp
+++ b/src/cpp/src/configuration/options.cpp
@@ -241,8 +241,8 @@ EdgeBucketOrdering getEdgeBucketOrderingEnum(std::string string_val) {
         return EdgeBucketOrdering::NEW_BETA;
     } else if (string_val == "ALL_BETA") {
         return EdgeBucketOrdering::ALL_BETA;
-    } else if (string_val == "TWO_LEVEL_BETA") {
-        return EdgeBucketOrdering::TWO_LEVEL_BETA;
+    } else if (string_val == "COMET") {
+        return EdgeBucketOrdering::COMET;
     } else if (string_val == "CUSTOM") {
         return EdgeBucketOrdering::CUSTOM;
     } else {

--- a/src/cpp/src/data/ordering.cpp
+++ b/src/cpp/src/data/ordering.cpp
@@ -21,8 +21,8 @@ std::tuple<vector<torch::Tensor>, vector<torch::Tensor>> getEdgeBucketOrdering(E
             return getTwoLevelBetaOrdering(num_partitions, buffer_capacity, 1, 0, true);
         case EdgeBucketOrdering::ALL_BETA:
             return getCustomEdgeBucketOrdering();
-        case EdgeBucketOrdering::TWO_LEVEL_BETA:
-            SPDLOG_INFO("Generating Two Level Beta Ordering");
+        case EdgeBucketOrdering::COMET:
+            SPDLOG_INFO("Generating COMET Ordering");
             return getTwoLevelBetaOrdering(num_partitions, buffer_capacity, fine_to_coarse_ratio, num_cache_partitions, randomly_assign_edge_buckets);
         case EdgeBucketOrdering::CUSTOM:
             return getCustomEdgeBucketOrdering();

--- a/src/python/tools/configuration/datatypes.py
+++ b/src/python/tools/configuration/datatypes.py
@@ -164,7 +164,7 @@ class PartitionBufferOptions(StorageOptions):
     prefetching: bool = True
     fine_to_coarse_ratio: int = 1
     num_cache_partitions: int = 0
-    edge_bucket_ordering: str = "NEW_BETA"
+    edge_bucket_ordering: str = "COMET"
     node_partition_ordering: str = "DISPERSED"
     randomly_assign_edge_buckets: bool = True
 

--- a/test/test_configs/lp/storage/part_buffer.yaml
+++ b/test/test_configs/lp/storage/part_buffer.yaml
@@ -12,7 +12,7 @@ embeddings:
     prefetching: false
     fine_to_coarse_ratio: 2
     num_cache_partitions: 0
-    edge_bucket_ordering: TWO_LEVEL_BETA
+    edge_bucket_ordering: COMET
     randomly_assign_edge_buckets: true
 features:
   type: PARTITION_BUFFER
@@ -22,6 +22,6 @@ features:
     prefetching: false
     fine_to_coarse_ratio: 2
     num_cache_partitions: 0
-    edge_bucket_ordering: TWO_LEVEL_BETA
+    edge_bucket_ordering: COMET
     randomly_assign_edge_buckets: true
 save_model: true


### PR DESCRIPTION
This pull request contains minor naming updates to match the new version of the MariusGNN paper. This includes renaming Marius++ to MariusGNN in the README, and renaming the config option for TWO_LEVEL_BETA to COMET.