### PR TITLE
Migrated products dataset to new syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ Thumbs.db
 
 
 # End of https://www.toptal.com/developers/gitignore/api/python
+.vscode/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter"
-    },
-    "python.formatting.provider": "none"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    "python.formatting.provider": "none"
+}

--- a/src/python/tools/preprocess/datasets/ogbn_products.py
+++ b/src/python/tools/preprocess/datasets/ogbn_products.py
@@ -80,7 +80,6 @@ class OGBNProducts(NodeClassificationDataset):
             output_dir=self.output_directory,
             train_edges=self.input_edge_list_file,
             num_partitions=num_partitions,
-            columns=[0, 1],
             src_column=0,
             dst_column=1,
             remap_ids=remap_ids,


### PR DESCRIPTION
Got rid of the `columns` argument when calling the converter from the products dataset